### PR TITLE
Add `sin`, `cos`, `tan` trigonometric methods and `pi` function

### DIFF
--- a/internal/impl/pure/bloblang_numbers.go
+++ b/internal/impl/pure/bloblang_numbers.go
@@ -232,6 +232,24 @@ root.outs = this.ins.map_each(ele -> ele.abs())
 		panic(err)
 	}
 
+	if err := bloblang.RegisterMethodV2("tan",
+		bloblang.NewPluginSpec().
+			Category(query.MethodCategoryNumbers).
+			Description(`Calculates the tangent of a given angle specified in radians.`).
+			Example("", `root.new_value = (this.value * (pi() / 180)).tan()`,
+				[2]string{`{"value":0}`, `{"new_value":0}`}).
+			Example("", `root.new_value = (this.value * (pi() / 180)).tan()`,
+				[2]string{`{"value":45}`, `{"new_value":1}`}).
+			Example("", `root.new_value = (this.value * (pi() / 180)).tan()`,
+				[2]string{`{"value":180}`, `{"new_value":0.32491}`}),
+		func(args *bloblang.ParsedParams) (bloblang.Method, error) {
+			return bloblang.Float64Method(func(input float64) (any, error) {
+				return math.Tan(input), nil
+			}), nil
+		}); err != nil {
+		panic(err)
+	}
+
 	//------------------------------------------------------------------------------
 
 	if err := bloblang.RegisterFunctionV2("pi",

--- a/internal/impl/pure/bloblang_numbers.go
+++ b/internal/impl/pure/bloblang_numbers.go
@@ -214,6 +214,24 @@ root.outs = this.ins.map_each(ele -> ele.abs())
 		panic(err)
 	}
 
+	if err := bloblang.RegisterMethodV2("cos",
+		bloblang.NewPluginSpec().
+			Category(query.MethodCategoryNumbers).
+			Description(`Calculates the cosine of a given angle specified in radians.`).
+			Example("", `root.new_value = (this.value * (pi() / 180)).cos()`,
+				[2]string{`{"value":45}`, `{"new_value":0.707}`}).
+			Example("", `root.new_value = (this.value * (pi() / 180)).cos()`,
+				[2]string{`{"value":0}`, `{"new_value":1}`}).
+			Example("", `root.new_value = (this.value * (pi() / 180)).cos()`,
+				[2]string{`{"value":180}`, `{"new_value":-1}`}),
+		func(args *bloblang.ParsedParams) (bloblang.Method, error) {
+			return bloblang.Float64Method(func(input float64) (any, error) {
+				return math.Cos(input), nil
+			}), nil
+		}); err != nil {
+		panic(err)
+	}
+
 	//------------------------------------------------------------------------------
 
 	if err := bloblang.RegisterFunctionV2("pi",

--- a/internal/impl/pure/bloblang_numbers.go
+++ b/internal/impl/pure/bloblang_numbers.go
@@ -195,4 +195,22 @@ root.outs = this.ins.map_each(ele -> ele.abs())
 		}); err != nil {
 		panic(err)
 	}
+
+	//------------------------------------------------------------------------------
+
+	if err := bloblang.RegisterFunctionV2("pi",
+		bloblang.NewPluginSpec().
+			Category(query.FunctionCategoryGeneral).
+			Description(`Returns the value of the mathematical constant Pi.`).
+			Example("", `root.radians = this.degrees * (pi() / 180)`,
+				[2]string{`{"degrees":45}`, `{"radians":0.78540}`}).
+			Example("", `root.degrees = this.radians * (180 / pi())`,
+				[2]string{`{"radians":0.78540}`, `{"degrees":45}`}),
+		func(args *bloblang.ParsedParams) (bloblang.Function, error) {
+			return func() (any, error) {
+				return math.Pi, nil
+			}, nil
+		}); err != nil {
+		panic(err)
+	}
 }

--- a/internal/impl/pure/bloblang_numbers.go
+++ b/internal/impl/pure/bloblang_numbers.go
@@ -196,6 +196,24 @@ root.outs = this.ins.map_each(ele -> ele.abs())
 		panic(err)
 	}
 
+	if err := bloblang.RegisterMethodV2("sin",
+		bloblang.NewPluginSpec().
+			Category(query.MethodCategoryNumbers).
+			Description(`Calculates the sine of a given angle specified in radians.`).
+			Example("", `root.new_value = (this.value * (pi() / 180)).sin()`,
+				[2]string{`{"value":45}`, `{"new_value":0.707}`}).
+			Example("", `root.new_value = (this.value * (pi() / 180)).sin()`,
+				[2]string{`{"value":0}`, `{"new_value":0}`}).
+			Example("", `root.new_value = (this.value * (pi() / 180)).sin()`,
+				[2]string{`{"value":90}`, `{"new_value":1}`}),
+		func(args *bloblang.ParsedParams) (bloblang.Method, error) {
+			return bloblang.Float64Method(func(input float64) (any, error) {
+				return math.Sin(input), nil
+			}), nil
+		}); err != nil {
+		panic(err)
+	}
+
 	//------------------------------------------------------------------------------
 
 	if err := bloblang.RegisterFunctionV2("pi",


### PR DESCRIPTION
Add the `sin`, `cos` and `tan` trigonometric methods:
- sin
- cos
- tan
and the Pi constant as a function to, among others, convert between radians and degrees.

```yml
root.new_value = (this.value * (pi() / 180)).sin()

# In: {"value":90}
# Out: {"new_value":1}
```