### PR TITLE
Add public APIs for custom stream builder schemas

### DIFF
--- a/internal/transaction/result_store.go
+++ b/internal/transaction/result_store.go
@@ -78,6 +78,14 @@ func NewResultStore() ResultStore {
 
 //------------------------------------------------------------------------------
 
+// AddResultStoreMsg sets a result store within the context of the provided
+// message that allows a roundtrip.Writer or any other component to propagate a
+// resulting message back to the origin.
+func AddResultStoreMsg(p *message.Part, store ResultStore) *message.Part {
+	ctx := message.GetContext(p)
+	return message.WithContext(context.WithValue(ctx, ResultStoreKey, store), p)
+}
+
 // AddResultStore sets a result store within the context of the provided message
 // that allows a roundtrip.Writer or any other component to propagate a
 // resulting message back to the origin.

--- a/public/service/message_test.go
+++ b/public/service/message_test.go
@@ -490,3 +490,30 @@ func BenchmarkMessageMappingOld(b *testing.B) {
 		}, resI)
 	}
 }
+
+func TestSyncResponse(t *testing.T) {
+	msgA := NewMessage([]byte("hello world a"))
+
+	msgB, storeB := msgA.WithSyncResponseStore()
+	msgB.SetBytes([]byte("hello world b"))
+
+	require.Error(t, msgA.AddSyncResponse())
+	require.NoError(t, msgB.AddSyncResponse())
+
+	msgC := msgB.Copy()
+	msgC.SetBytes([]byte("hello world c"))
+	require.NoError(t, msgC.AddSyncResponse())
+
+	resBatches := storeB.Read()
+	require.Len(t, resBatches, 2)
+	require.Len(t, resBatches[0], 1)
+	require.Len(t, resBatches[1], 1)
+
+	data, err := resBatches[0][0].AsBytes()
+	require.NoError(t, err)
+	assert.Equal(t, "hello world b", string(data))
+
+	data, err = resBatches[1][0].AsBytes()
+	require.NoError(t, err)
+	assert.Equal(t, "hello world c", string(data))
+}

--- a/public/service/stream_builder.go
+++ b/public/service/stream_builder.go
@@ -7,7 +7,6 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
-	"sync/atomic"
 
 	"github.com/Jeffail/gabs/v2"
 	"github.com/gofrs/uuid"
@@ -66,6 +65,7 @@ type StreamBuilder struct {
 	apiMut       manager.APIReg
 	customLogger log.Modular
 
+	configSpec      docs.FieldSpecs
 	env             *Environment
 	lintingDisabled bool
 	envVarLookupFn  func(string) (string, bool)
@@ -75,14 +75,18 @@ type StreamBuilder struct {
 func NewStreamBuilder() *StreamBuilder {
 	httpConf := api.NewConfig()
 	httpConf.Enabled = false
+
+	tmpSpec := config.Spec()
+	tmpSpec.SetDefault(false, "http", "enabled")
+
 	return &StreamBuilder{
-		engineVersion:  cli.Version,
 		http:           httpConf,
 		buffer:         buffer.NewConfig(),
 		resources:      manager.NewResourceConfig(),
 		metrics:        metrics.NewConfig(),
 		tracer:         tracer.NewConfig(),
 		logger:         log.NewConfig(),
+		configSpec:     tmpSpec,
 		env:            globalEnvironment,
 		envVarLookupFn: os.LookupEnv,
 	}
@@ -102,6 +106,20 @@ func (s *StreamBuilder) getLintContext() docs.LintContext {
 // version either from the benthos module import or a build-time flag.
 func (s *StreamBuilder) SetEngineVersion(ev string) {
 	s.engineVersion = ev
+}
+
+// SetSchema overrides the default config schema used when linting and parsing
+// full configs with the SetYAML method. Other XYAML methods will not use this
+// schema as they parse individual component configs rather than a larger
+// configuration.
+//
+// This method is useful as a mechanism for modifying the default top-level
+// settings, such as metrics types and so on.
+func (s *StreamBuilder) SetSchema(schema *ConfigSchema) {
+	if s.engineVersion == "" {
+		s.engineVersion = schema.version
+	}
+	s.configSpec = schema.fields
 }
 
 // DisableLinting configures the stream builder to no longer lint YAML configs,
@@ -509,7 +527,7 @@ func (s *StreamBuilder) SetYAML(conf string) error {
 		return err
 	}
 
-	spec := configSpec()
+	spec := s.configSpec
 	if err := s.lintYAMLSpec(spec, node); err != nil {
 		return err
 	}
@@ -526,19 +544,6 @@ func (s *StreamBuilder) SetYAML(conf string) error {
 
 	s.setFromConfig(sconf)
 	return nil
-}
-
-var builderConfigSpec atomic.Pointer[docs.FieldSpecs]
-
-func configSpec() docs.FieldSpecs {
-	spec := builderConfigSpec.Load()
-	if spec == nil {
-		tmpSpec := config.Spec()
-		tmpSpec.SetDefault(false, "http", "enabled")
-		spec = &tmpSpec
-		builderConfigSpec.Store(spec)
-	}
-	return *spec
 }
 
 // SetFields modifies the config by setting one or more fields identified by a
@@ -566,7 +571,7 @@ func (s *StreamBuilder) SetFields(pathValues ...any) error {
 	sanitConf.RemoveDeprecated = false
 	sanitConf.DocsProvider = s.env.internal
 
-	if err := configSpec().SanitiseYAML(&rootNode, sanitConf); err != nil {
+	if err := s.configSpec.SanitiseYAML(&rootNode, sanitConf); err != nil {
 		return err
 	}
 
@@ -579,12 +584,12 @@ func (s *StreamBuilder) SetFields(pathValues ...any) error {
 		if !ok {
 			return fmt.Errorf("variadic pair element %v should be a string, got a %T", i, pathValues[i])
 		}
-		if err := configSpec().SetYAMLPath(s.env.internal, &rootNode, &valueNode, gabs.DotPathToSlice(pathString)...); err != nil {
+		if err := s.configSpec.SetYAMLPath(s.env.internal, &rootNode, &valueNode, gabs.DotPathToSlice(pathString)...); err != nil {
 			return err
 		}
 	}
 
-	spec := configSpec()
+	spec := s.configSpec
 	if err := s.lintYAMLSpec(spec, &rootNode); err != nil {
 		return err
 	}
@@ -724,7 +729,7 @@ func (s *StreamBuilder) AsYAML() (string, error) {
 	sanitConf.RemoveDeprecated = false
 	sanitConf.DocsProvider = s.env.internal
 
-	if err := configSpec().SanitiseYAML(&node, sanitConf); err != nil {
+	if err := s.configSpec.SanitiseYAML(&node, sanitConf); err != nil {
 		return "", err
 	}
 
@@ -767,7 +772,7 @@ func (s *StreamBuilder) WalkComponents(fn func(w *WalkedComponent) error) error 
 	sanitConf.RemoveDeprecated = false
 	sanitConf.DocsProvider = s.env.internal
 
-	spec := configSpec()
+	spec := s.configSpec
 	if err := spec.SanitiseYAML(&node, sanitConf); err != nil {
 		return err
 	}
@@ -847,6 +852,11 @@ func (s *StreamBuilder) buildWithEnv(env *bundle.Environment) (*Stream, error) {
 		}
 	}
 
+	engVer := s.engineVersion
+	if engVer == "" {
+		engVer = cli.Version
+	}
+
 	// This temporary manager is a very lazy way of instantiating a manager that
 	// restricts the bloblang and component environments to custom plugins.
 	// Ideally we would break out the constructor for our general purpose
@@ -854,7 +864,7 @@ func (s *StreamBuilder) buildWithEnv(env *bundle.Environment) (*Stream, error) {
 	// resource constructors until after this metrics exporter is initialised.
 	tmpMgr, err := manager.New(
 		manager.NewResourceConfig(),
-		manager.OptSetEngineVersion(s.engineVersion),
+		manager.OptSetEngineVersion(engVer),
 		manager.OptSetLogger(logger),
 		manager.OptSetEnvironment(env),
 		manager.OptSetBloblangEnvironment(s.env.getBloblangParserEnv()),
@@ -883,7 +893,7 @@ func (s *StreamBuilder) buildWithEnv(env *bundle.Environment) (*Stream, error) {
 			sanitConf.RemoveTypeField = true
 			sanitConf.ScrubSecrets = true
 			sanitConf.DocsProvider = env
-			_ = configSpec().SanitiseYAML(&sanitNode, sanitConf)
+			_ = s.configSpec.SanitiseYAML(&sanitNode, sanitConf)
 		}
 		if apiType, err = api.New("", "", s.http, sanitNode, logger, stats); err != nil {
 			return nil, fmt.Errorf("unable to create stream HTTP server due to: %w. Tip: you can disable the server with `http.enabled` set to `false`, or override the configured server with SetHTTPMux", err)

--- a/public/service/stream_schema.go
+++ b/public/service/stream_schema.go
@@ -274,6 +274,15 @@ func (s *ConfigSchema) SetVersion(version, dateBuilt string) *ConfigSchema {
 	return s
 }
 
+// SetFieldDefault attempts to change the default value of a field in the config
+// spec, which is the value used when the field is omitted from the config.
+//
+// This method does NOT support walking into arrays, nor component configs
+// themselves.
+func (s *ConfigSchema) SetFieldDefault(value any, path ...string) {
+	s.fields.SetDefault(value, path...)
+}
+
 // Field adds a field to the main config of a schema.
 func (s *ConfigSchema) Field(f *ConfigField) *ConfigSchema {
 	s.fields = append(s.fields, f.field)


### PR DESCRIPTION
This is a suite of public APIs for:
- Creating a stream builder with a custom full config schema (allows us to customise default values)
- Receiving synchronous responses from messages created using the public APIs

These two features are required for creating a serverless handler using public APIs.