### PR TITLE
Add proxy_url field to the websocket components

### DIFF
--- a/internal/impl/io/input_websocket.go
+++ b/internal/impl/io/input_websocket.go
@@ -40,6 +40,9 @@ func websocketInputSpec() *service.ConfigSpec {
 			service.NewURLField("url").
 				Description("The URL to connect to.").
 				Example("ws://localhost:4195/get/ws"),
+			service.NewURLField("proxy_url").
+				Description("An optional HTTP proxy URL.").
+				Advanced().Optional(),
 			service.NewStringField("open_message").
 				Description("An optional message to send to the server upon connection.").
 				Advanced().Optional(),
@@ -92,12 +95,13 @@ type websocketReader struct {
 
 	lock *sync.Mutex
 
-	client     *websocket.Conn
-	urlParsed  *url.URL
-	urlStr     string
-	tlsEnabled bool
-	tlsConf    *tls.Config
-	reqSigner  func(f fs.FS, req *http.Request) error
+	client         *websocket.Conn
+	urlParsed      *url.URL
+	urlStr         string
+	proxyURLParsed *url.URL
+	tlsEnabled     bool
+	tlsConf        *tls.Config
+	reqSigner      func(f fs.FS, req *http.Request) error
 
 	openMsgType wsOpenMsgType
 	openMsg     []byte
@@ -115,6 +119,11 @@ func newWebsocketReaderFromParsed(conf *service.ParsedConfig, mgr bundle.NewMana
 	}
 	if ws.urlStr, err = conf.FieldString("url"); err != nil {
 		return nil, err
+	}
+	if conf.Contains("proxy_url") {
+		if ws.proxyURLParsed, err = conf.FieldURL("proxy_url"); err != nil {
+			return nil, err
+		}
 	}
 	if ws.tlsConf, ws.tlsEnabled, err = conf.FieldTLSToggled("tls"); err != nil {
 		return nil, err
@@ -169,14 +178,17 @@ func (w *websocketReader) Connect(ctx context.Context) error {
 		}
 	}()
 
+	dialer := *websocket.DefaultDialer
+	if w.proxyURLParsed != nil {
+		dialer.Proxy = http.ProxyURL(w.proxyURLParsed)
+	}
+
 	if w.tlsEnabled {
-		dialer := websocket.Dialer{
-			TLSClientConfig: w.tlsConf,
-		}
+		dialer.TLSClientConfig = w.tlsConf
 		if client, res, err = dialer.Dial(w.urlStr, headers); err != nil {
 			return err
 		}
-	} else if client, res, err = websocket.DefaultDialer.Dial(w.urlStr, headers); err != nil {
+	} else if client, res, err = dialer.Dial(w.urlStr, headers); err != nil {
 		return err
 	}
 

--- a/internal/impl/io/output_websocket.go
+++ b/internal/impl/io/output_websocket.go
@@ -26,6 +26,7 @@ func websocketOutputSpec() *service.ConfigSpec {
 		Categories("Network").
 		Summary("Sends messages to an HTTP server via a websocket connection.").
 		Field(service.NewURLField("url").Description("The URL to connect to.")).
+		Field(service.NewURLField("proxy_url").Description("An optional HTTP proxy URL.").Advanced().Optional()).
 		Field(service.NewTLSToggledField("tls"))
 
 	for _, f := range service.NewHTTPRequestAuthSignerFields() {
@@ -63,12 +64,13 @@ type websocketWriter struct {
 
 	lock *sync.Mutex
 
-	client     *websocket.Conn
-	urlParsed  *url.URL
-	urlStr     string
-	tlsEnabled bool
-	tlsConf    *tls.Config
-	reqSigner  func(f fs.FS, req *http.Request) error
+	client         *websocket.Conn
+	urlParsed      *url.URL
+	urlStr         string
+	proxyURLParsed *url.URL
+	tlsEnabled     bool
+	tlsConf        *tls.Config
+	reqSigner      func(f fs.FS, req *http.Request) error
 }
 
 func newWebsocketWriterFromParsed(conf *service.ParsedConfig, mgr bundle.NewManagement) (*websocketWriter, error) {
@@ -84,6 +86,11 @@ func newWebsocketWriterFromParsed(conf *service.ParsedConfig, mgr bundle.NewMana
 	}
 	if ws.urlStr, err = conf.FieldString("url"); err != nil {
 		return nil, err
+	}
+	if conf.Contains("proxy_url") {
+		if ws.proxyURLParsed, err = conf.FieldURL("proxy_url"); err != nil {
+			return nil, err
+		}
 	}
 	if ws.tlsConf, ws.tlsEnabled, err = conf.FieldTLSToggled("tls"); err != nil {
 		return nil, err
@@ -130,14 +137,17 @@ func (w *websocketWriter) Connect(ctx context.Context) error {
 		}
 	}()
 
+	dialer := *websocket.DefaultDialer
+	if w.proxyURLParsed != nil {
+		dialer.Proxy = http.ProxyURL(w.proxyURLParsed)
+	}
+
 	if w.tlsEnabled {
-		dialer := websocket.Dialer{
-			TLSClientConfig: w.tlsConf,
-		}
+		dialer.TLSClientConfig = w.tlsConf
 		if client, res, err = dialer.Dial(w.urlStr, headers); err != nil {
 			return err
 		}
-	} else if client, res, err = websocket.DefaultDialer.Dial(w.urlStr, headers); err != nil {
+	} else if client, res, err = dialer.Dial(w.urlStr, headers); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
Note: The `HTTP_PROXY`, `HTTPS_PROXY` and `NO_PROXY` environment variables can be used as fallback when this field isn't set. Details here: <https://pkg.go.dev/golang.org/x/net/http/httpproxy#FromEnvironment>.