### PR TITLE
Add blobl example tests back in

### DIFF
--- a/internal/impl/io/bloblang_examples_test.go
+++ b/internal/impl/io/bloblang_examples_test.go
@@ -1,0 +1,165 @@
+package io_test
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/propagation"
+	"go.opentelemetry.io/otel/trace/noop"
+
+	"github.com/redpanda-data/benthos/v4/public/bloblang"
+	"github.com/redpanda-data/benthos/v4/public/service"
+
+	_ "github.com/redpanda-data/benthos/v4/internal/impl/io"
+)
+
+func TestFunctionExamples(t *testing.T) {
+	tmpJSONFile, err := os.CreateTemp("", "benthos_bloblang_functions_test")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		os.Remove(tmpJSONFile.Name())
+	})
+
+	_, err = tmpJSONFile.WriteString(`{"foo":"bar"}`)
+	require.NoError(t, err)
+
+	key := "BENTHOS_TEST_BLOBLANG_FILE"
+	t.Setenv(key, tmpJSONFile.Name())
+
+	env := bloblang.GlobalEnvironment()
+	env.WalkFunctions(func(name string, view *bloblang.FunctionView) {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			spec := view.TemplateData()
+			for i, e := range spec.Examples {
+				if e.SkipTesting {
+					continue
+				}
+
+				m, err := env.Parse(e.Mapping)
+				require.NoError(t, err)
+
+				for j, io := range e.Results {
+					msg := service.NewMessage([]byte(io[0]))
+					textMap := propagation.MapCarrier{
+						"traceparent": "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
+					}
+					otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(propagation.TraceContext{}))
+
+					textProp := otel.GetTextMapPropagator()
+					otelCtx := textProp.Extract(msg.Context(), textMap)
+					pCtx, _ := noop.NewTracerProvider().Tracer("blobby").Start(otelCtx, "test")
+					msg = msg.WithContext(pCtx)
+
+					p, err := msg.BloblangQuery(m)
+					exp := io[1]
+					if strings.HasPrefix(exp, "Error(") {
+						exp = exp[7 : len(exp)-2]
+						require.EqualError(t, err, exp, fmt.Sprintf("%v-%v", i, j))
+					} else {
+						require.NoError(t, err)
+
+						pBytes, err := p.AsBytes()
+						require.NoError(t, err)
+
+						assert.Equal(t, exp, string(pBytes), fmt.Sprintf("%v-%v", i, j))
+					}
+				}
+			}
+		})
+	})
+}
+
+func TestMethodExamples(t *testing.T) {
+	tmpJSONFile, err := os.CreateTemp("", "benthos_bloblang_methods_test")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		os.Remove(tmpJSONFile.Name())
+	})
+
+	_, err = tmpJSONFile.WriteString(`
+{
+  "type":"object",
+  "properties":{
+    "foo":{
+      "type":"string"
+    }
+  }
+}`)
+	require.NoError(t, err)
+
+	key := "BENTHOS_TEST_BLOBLANG_SCHEMA_FILE"
+	t.Setenv(key, tmpJSONFile.Name())
+
+	env := bloblang.GlobalEnvironment()
+	env.WalkMethods(func(name string, view *bloblang.MethodView) {
+		spec := view.TemplateData()
+		t.Run(spec.Name, func(t *testing.T) {
+			t.Parallel()
+			for i, e := range spec.Examples {
+				if e.SkipTesting {
+					continue
+				}
+
+				m, err := env.Parse(e.Mapping)
+				require.NoError(t, err)
+
+				for j, io := range e.Results {
+					msg := service.NewMessage([]byte(io[0]))
+					p, err := msg.BloblangQuery(m)
+					exp := io[1]
+					if strings.HasPrefix(exp, "Error(") {
+						exp = exp[7 : len(exp)-2]
+						require.EqualError(t, err, exp, fmt.Sprintf("%v-%v", i, j))
+					} else if exp == "<Message deleted>" {
+						require.NoError(t, err)
+						require.Nil(t, p)
+					} else {
+						require.NoError(t, err)
+
+						pBytes, err := p.AsBytes()
+						require.NoError(t, err)
+
+						assert.Equal(t, exp, string(pBytes), fmt.Sprintf("%v-%v", i, j))
+					}
+				}
+			}
+			for _, target := range spec.Categories {
+				for i, e := range target.Examples {
+					if e.SkipTesting {
+						continue
+					}
+
+					m, err := env.Parse(e.Mapping)
+					require.NoError(t, err)
+
+					for j, io := range e.Results {
+						msg := service.NewMessage([]byte(io[0]))
+						p, err := msg.BloblangQuery(m)
+						exp := io[1]
+						if strings.HasPrefix(exp, "Error(") {
+							exp = exp[7 : len(exp)-2]
+							require.EqualError(t, err, exp, fmt.Sprintf("%v-%v", i, j))
+						} else if exp == "<Message deleted>" {
+							require.NoError(t, err)
+							require.Nil(t, p)
+						} else {
+							require.NoError(t, err)
+
+							pBytes, err := p.AsBytes()
+							require.NoError(t, err)
+
+							assert.Equal(t, exp, string(pBytes), fmt.Sprintf("%v-%v", i, j))
+						}
+					}
+				}
+			}
+		})
+	})
+}

--- a/internal/impl/pure/bloblang_examples_test.go
+++ b/internal/impl/pure/bloblang_examples_test.go
@@ -1,0 +1,165 @@
+package pure_test
+
+import (
+	"fmt"
+	"os"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/propagation"
+	"go.opentelemetry.io/otel/trace/noop"
+
+	"github.com/redpanda-data/benthos/v4/public/bloblang"
+	"github.com/redpanda-data/benthos/v4/public/service"
+
+	_ "github.com/redpanda-data/benthos/v4/internal/impl/pure"
+)
+
+func TestFunctionExamples(t *testing.T) {
+	tmpJSONFile, err := os.CreateTemp("", "benthos_bloblang_functions_test")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		os.Remove(tmpJSONFile.Name())
+	})
+
+	_, err = tmpJSONFile.WriteString(`{"foo":"bar"}`)
+	require.NoError(t, err)
+
+	key := "BENTHOS_TEST_BLOBLANG_FILE"
+	t.Setenv(key, tmpJSONFile.Name())
+
+	env := bloblang.GlobalEnvironment()
+	env.WalkFunctions(func(name string, view *bloblang.FunctionView) {
+		t.Run(name, func(t *testing.T) {
+			t.Parallel()
+
+			spec := view.TemplateData()
+			for i, e := range spec.Examples {
+				if e.SkipTesting {
+					continue
+				}
+
+				m, err := env.Parse(e.Mapping)
+				require.NoError(t, err)
+
+				for j, io := range e.Results {
+					msg := service.NewMessage([]byte(io[0]))
+					textMap := propagation.MapCarrier{
+						"traceparent": "00-4bf92f3577b34da6a3ce929d0e0e4736-00f067aa0ba902b7-01",
+					}
+					otel.SetTextMapPropagator(propagation.NewCompositeTextMapPropagator(propagation.TraceContext{}))
+
+					textProp := otel.GetTextMapPropagator()
+					otelCtx := textProp.Extract(msg.Context(), textMap)
+					pCtx, _ := noop.NewTracerProvider().Tracer("blobby").Start(otelCtx, "test")
+					msg = msg.WithContext(pCtx)
+
+					p, err := msg.BloblangQuery(m)
+					exp := io[1]
+					if strings.HasPrefix(exp, "Error(") {
+						exp = exp[7 : len(exp)-2]
+						require.EqualError(t, err, exp, fmt.Sprintf("%v-%v", i, j))
+					} else {
+						require.NoError(t, err)
+
+						pBytes, err := p.AsBytes()
+						require.NoError(t, err)
+
+						assert.Equal(t, exp, string(pBytes), fmt.Sprintf("%v-%v", i, j))
+					}
+				}
+			}
+		})
+	})
+}
+
+func TestMethodExamples(t *testing.T) {
+	tmpJSONFile, err := os.CreateTemp("", "benthos_bloblang_methods_test")
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		os.Remove(tmpJSONFile.Name())
+	})
+
+	_, err = tmpJSONFile.WriteString(`
+{
+  "type":"object",
+  "properties":{
+    "foo":{
+      "type":"string"
+    }
+  }
+}`)
+	require.NoError(t, err)
+
+	key := "BENTHOS_TEST_BLOBLANG_SCHEMA_FILE"
+	t.Setenv(key, tmpJSONFile.Name())
+
+	env := bloblang.GlobalEnvironment()
+	env.WalkMethods(func(name string, view *bloblang.MethodView) {
+		spec := view.TemplateData()
+		t.Run(spec.Name, func(t *testing.T) {
+			t.Parallel()
+			for i, e := range spec.Examples {
+				if e.SkipTesting {
+					continue
+				}
+
+				m, err := env.Parse(e.Mapping)
+				require.NoError(t, err)
+
+				for j, io := range e.Results {
+					msg := service.NewMessage([]byte(io[0]))
+					p, err := msg.BloblangQuery(m)
+					exp := io[1]
+					if strings.HasPrefix(exp, "Error(") {
+						exp = exp[7 : len(exp)-2]
+						require.EqualError(t, err, exp, fmt.Sprintf("%v-%v", i, j))
+					} else if exp == "<Message deleted>" {
+						require.NoError(t, err)
+						require.Nil(t, p)
+					} else {
+						require.NoError(t, err)
+
+						pBytes, err := p.AsBytes()
+						require.NoError(t, err)
+
+						assert.Equal(t, exp, string(pBytes), fmt.Sprintf("%v-%v", i, j))
+					}
+				}
+			}
+			for _, target := range spec.Categories {
+				for i, e := range target.Examples {
+					if e.SkipTesting {
+						continue
+					}
+
+					m, err := env.Parse(e.Mapping)
+					require.NoError(t, err)
+
+					for j, io := range e.Results {
+						msg := service.NewMessage([]byte(io[0]))
+						p, err := msg.BloblangQuery(m)
+						exp := io[1]
+						if strings.HasPrefix(exp, "Error(") {
+							exp = exp[7 : len(exp)-2]
+							require.EqualError(t, err, exp, fmt.Sprintf("%v-%v", i, j))
+						} else if exp == "<Message deleted>" {
+							require.NoError(t, err)
+							require.Nil(t, p)
+						} else {
+							require.NoError(t, err)
+
+							pBytes, err := p.AsBytes()
+							require.NoError(t, err)
+
+							assert.Equal(t, exp, string(pBytes), fmt.Sprintf("%v-%v", i, j))
+						}
+					}
+				}
+			}
+		})
+	})
+}

--- a/internal/impl/pure/bloblang_numbers.go
+++ b/internal/impl/pure/bloblang_numbers.go
@@ -232,10 +232,10 @@ root.outs = this.ins.map_each(ele -> ele.abs())
 		bloblang.NewPluginSpec().
 			Category(query.MethodCategoryNumbers).
 			Description(`Calculates the tangent of a given angle specified in radians.`).
-			Example("", `root.new_value = (this.value * (pi() / 180)).tan()`,
-				[2]string{`{"value":0}`, `{"new_value":0}`},
-				[2]string{`{"value":45}`, `{"new_value":0.9999999999999998}`},
-				[2]string{`{"value":180}`, `{"new_value":-1.2246467991473515e-16}`}),
+			Example("", `root.new_value = "%f".format((this.value * (pi() / 180)).tan())`,
+				[2]string{`{"value":0}`, `{"new_value":"0.000000"}`},
+				[2]string{`{"value":45}`, `{"new_value":"1.000000"}`},
+				[2]string{`{"value":180}`, `{"new_value":"-0.000000"}`}),
 		func(args *bloblang.ParsedParams) (bloblang.Method, error) {
 			return bloblang.Float64Method(func(input float64) (any, error) {
 				return math.Tan(input), nil

--- a/internal/impl/pure/bloblang_numbers.go
+++ b/internal/impl/pure/bloblang_numbers.go
@@ -201,7 +201,7 @@ root.outs = this.ins.map_each(ele -> ele.abs())
 			Category(query.MethodCategoryNumbers).
 			Description(`Calculates the sine of a given angle specified in radians.`).
 			Example("", `root.new_value = (this.value * (pi() / 180)).sin()`,
-				[2]string{`{"value":45}`, `{"new_value":0.707}`},
+				[2]string{`{"value":45}`, `{"new_value":0.7071067811865475}`},
 				[2]string{`{"value":0}`, `{"new_value":0}`},
 				[2]string{`{"value":90}`, `{"new_value":1}`}),
 		func(args *bloblang.ParsedParams) (bloblang.Method, error) {
@@ -217,7 +217,7 @@ root.outs = this.ins.map_each(ele -> ele.abs())
 			Category(query.MethodCategoryNumbers).
 			Description(`Calculates the cosine of a given angle specified in radians.`).
 			Example("", `root.new_value = (this.value * (pi() / 180)).cos()`,
-				[2]string{`{"value":45}`, `{"new_value":0.707}`},
+				[2]string{`{"value":45}`, `{"new_value":0.7071067811865476}`},
 				[2]string{`{"value":0}`, `{"new_value":1}`},
 				[2]string{`{"value":180}`, `{"new_value":-1}`}),
 		func(args *bloblang.ParsedParams) (bloblang.Method, error) {
@@ -234,8 +234,8 @@ root.outs = this.ins.map_each(ele -> ele.abs())
 			Description(`Calculates the tangent of a given angle specified in radians.`).
 			Example("", `root.new_value = (this.value * (pi() / 180)).tan()`,
 				[2]string{`{"value":0}`, `{"new_value":0}`},
-				[2]string{`{"value":45}`, `{"new_value":1}`},
-				[2]string{`{"value":180}`, `{"new_value":0.32491}`}),
+				[2]string{`{"value":45}`, `{"new_value":0.9999999999999998}`},
+				[2]string{`{"value":180}`, `{"new_value":-1.2246467991473515e-16}`}),
 		func(args *bloblang.ParsedParams) (bloblang.Method, error) {
 			return bloblang.Float64Method(func(input float64) (any, error) {
 				return math.Tan(input), nil
@@ -251,9 +251,9 @@ root.outs = this.ins.map_each(ele -> ele.abs())
 			Category(query.FunctionCategoryGeneral).
 			Description(`Returns the value of the mathematical constant Pi.`).
 			Example("", `root.radians = this.degrees * (pi() / 180)`,
-				[2]string{`{"degrees":45}`, `{"radians":0.78540}`}).
+				[2]string{`{"degrees":45}`, `{"radians":0.7853981633974483}`}).
 			Example("", `root.degrees = this.radians * (180 / pi())`,
-				[2]string{`{"radians":0.78540}`, `{"degrees":45}`}),
+				[2]string{`{"radians":0.78540}`, `{"degrees":45.00010522957486}`}),
 		func(args *bloblang.ParsedParams) (bloblang.Function, error) {
 			return func() (any, error) {
 				return math.Pi, nil


### PR DESCRIPTION
The example tests used to be performed in a single place, which was the same package responsible for generating the docs. However, that package now exists within the connect repository and so it makes sense to add the tests in here so that we can catch example issues earlier.