### PR TITLE
Add "array" Method 

### DIFF
--- a/internal/bloblang/query/methods.go
+++ b/internal/bloblang/query/methods.go
@@ -78,6 +78,33 @@ func applyMethod(target Function, args *ParsedParams) (Function, error) {
 
 //------------------------------------------------------------------------------
 
+var _ = registerSimpleMethod(
+	NewMethodSpec(
+		"array", "",
+	).InCategory(
+		MethodCategoryCoercion,
+		"Marshal a value into an array. If the value is already an array it is unchanged.",
+		NewExampleSpec("",
+			`root.my_array = this.name.array()`,
+			`{"name":"foobar bazson"}`,
+			`{"my_array":["foobar bazson"]}`,
+		),
+	),
+	func(*ParsedParams) (simpleMethod, error) {
+		return func(v any, ctx FunctionContext) (any, error) {
+			switch v.(type) {
+			case []any:
+				return v, nil
+			}
+			arr := make([]any, 1)
+			arr[0] = v
+			return arr, nil
+		}, nil
+	},
+)
+
+//------------------------------------------------------------------------------
+
 var _ = registerMethod(
 	NewMethodSpec("bool", "").InCategory(
 		MethodCategoryCoercion,

--- a/internal/bloblang/query/methods_test.go
+++ b/internal/bloblang/query/methods_test.go
@@ -492,6 +492,34 @@ func TestMethods(t *testing.T) {
 			),
 			output: false,
 		},
+		"check array": {
+			input: methods(
+				literalFn([]any{1}),
+				method("array"),
+			),
+			output: []any{1},
+		},
+		"check array 2": {
+			input: methods(
+				literalFn(1),
+				method("array"),
+			),
+			output: []any{1},
+		},
+		"check array 3": {
+			input: methods(
+				literalFn(nil),
+				method("array"),
+			),
+			output: []any{nil},
+		},
+		"check array 4": {
+			input: methods(
+				literalFn([]any{}),
+				method("array"),
+			),
+			output: []any{},
+		},
 		"check bool": {
 			input: methods(
 				literalFn("true"),


### PR DESCRIPTION
These changes add an `array` type coercion **bloblang** method similar to the `bytes` method: If the caller is already of type array the input is returned. If it is any other type the input is wrapped into a one-element array. Such a method helps to avoid constructs like `this.with("name").values().flatten()` to ensure an array returned.

The docs for the `connect` repo can be extended by:
````
### `array`

Marshal a value into an array. If the value is already an array it is unchanged.

#### Examples


```coffee
root.my_array = this.name.array()

# In:  {"name":"foobar bazson"}
# Out: {"my_array":["foobar bazson"]}
```
````