### PR TITLE
Tighten up stream integration tests

### DIFF
--- a/public/service/integration/stream_test_helpers.go
+++ b/public/service/integration/stream_test_helpers.go
@@ -511,7 +511,10 @@ func receiveMessage(
 	require.NoError(t, ackFn(ctx, err))
 	require.Len(t, b, 1)
 
-	return b.Get(0)
+	msg := b.Get(0)
+	require.NoError(t, msg.ErrorGet())
+
+	return msg
 }
 
 func receiveBatch(


### PR DESCRIPTION
Reject messages which contain errors when running the integration test suite.

This comes in handy when one wants to attach some processors to the input(s) in integration tests for performing additional validations such as throwing an error if some expected metadata field isn't present or has the wrong value.