### PR TITLE
Add `escape_html` parameter to the `format_json` bloblang method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ Changelog
 
 All notable changes to this project will be documented in this file.
 
+## 4.30.1 - TBD
+
+### Added
+
+- Parameter `escape_html` added to the `format_json()` Bloblang method. (@mihaitodor)
+
 ## 4.30.0 - 2024-06-13
 
 ### Added

--- a/internal/bloblang/query/methods_strings.go
+++ b/internal/bloblang/query/methods_strings.go
@@ -1245,6 +1245,22 @@ var _ = registerSimpleMethod(
 			`{"doc":{"foo":"bar"}}`,
 			`{"foo":"bar"}`,
 		),
+		NewExampleSpec("Escapes problematic HTML characters.",
+			`root = this.doc.format_json()`,
+			`{"doc":{"email":"foo&bar@benthos.dev","name":"foo>bar"}}`,
+			`{
+    "email": "foo\u0026bar@benthos.dev",
+    "name": "foo\u003ebar"
+}`,
+		),
+		NewExampleSpec("Set the `escape_html` parameter to false to disable escaping of problematic HTML characters.",
+			`root = this.doc.format_json(escape_html: false)`,
+			`{"doc":{"email":"foo&bar@benthos.dev","name":"foo>bar"}}`,
+			`{
+    "email": "foo&bar@benthos.dev",
+    "name": "foo>bar"
+}`,
+		),
 	).
 		Beta().
 		Param(ParamString(
@@ -1254,7 +1270,11 @@ var _ = registerSimpleMethod(
 		Param(ParamBool(
 			"no_indent",
 			"Disable indentation.",
-		).Default(false)),
+		).Default(false)).
+		Param(ParamBool(
+			"escape_html",
+			"Escape problematic HTML characters.",
+		).Default(true)),
 	func(args *ParsedParams) (simpleMethod, error) {
 		indentOpt, err := args.FieldOptionalString("indent")
 		if err != nil {
@@ -1268,11 +1288,29 @@ var _ = registerSimpleMethod(
 		if err != nil {
 			return nil, err
 		}
+		escapeHTMLOpt, err := args.FieldOptionalBool("escape_html")
+		if err != nil {
+			return nil, err
+		}
 		return func(v any, ctx FunctionContext) (any, error) {
-			if *noIndentOpt {
-				return json.Marshal(v)
+			buffer := &bytes.Buffer{}
+
+			encoder := json.NewEncoder(buffer)
+			if !*noIndentOpt {
+				encoder.SetIndent("", indent)
 			}
-			return json.MarshalIndent(v, "", indent)
+			if !*escapeHTMLOpt {
+				encoder.SetEscapeHTML(false)
+			}
+
+			if err := encoder.Encode(v); err != nil {
+				return nil, err
+			}
+
+			// This hack is here because `format_json()` initially relied on `json.Marshal()` or `json.MarshalIndent()`
+			// which don't add a trailing newline to the output and, also, other `format_*` methods in bloblang don't
+			// append a trailing newline.
+			return bytes.TrimRight(buffer.Bytes(), "\n"), nil
 		}, nil
 	},
 )

--- a/internal/bloblang/query/methods_test.go
+++ b/internal/bloblang/query/methods_test.go
@@ -115,11 +115,21 @@ func TestMethods(t *testing.T) {
 				jsonFn(`{"doc":{"foo":"bar"}}`),
 				method("format_json", ""),
 			),
-			output: []byte(`{
-"doc": {
-"foo": "bar"
-}
-}`),
+			output: []byte(`{"doc":{"foo":"bar"}}`),
+		},
+		"check format_json with escaping problematic HTML characters": {
+			input: methods(
+				jsonFn(`{"doc":{"email":"foo&bar@benthos.dev","name":"foo>bar"}}`),
+				method("format_json", ""),
+			),
+			output: []byte(`{"doc":{"email":"foo\u0026bar@benthos.dev","name":"foo\u003ebar"}}`),
+		},
+		"check format_json without escaping problematic HTML characters": {
+			input: methods(
+				jsonFn(`{"doc":{"email":"foo&bar@benthos.dev","name":"foo>bar"}}`),
+				method("format_json", "", true, false),
+			),
+			output: []byte(`{"doc":{"email":"foo&bar@benthos.dev","name":"foo>bar"}}`),
 		},
 		"check format_yaml": {
 			input: methods(


### PR DESCRIPTION
This is related to https://github.com/redpanda-data/connect/issues/1253.