### PR TITLE
Add custom secrets opt func

### DIFF
--- a/internal/cli/common/manager.go
+++ b/internal/cli/common/manager.go
@@ -101,6 +101,8 @@ func CreateManager(
 		manager.OptSetMetrics(stats),
 		manager.OptSetTracer(trac),
 		manager.OptSetStreamsMode(streamsMode),
+		manager.OptSetBloblangEnvironment(cliOpts.BloblEnvironment),
+		manager.OptSetEnvironment(cliOpts.Environment),
 	}, mgrOpts...)
 
 	// Create resource manager.

--- a/internal/cli/common/manager.go
+++ b/internal/cli/common/manager.go
@@ -15,7 +15,6 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/redpanda-data/benthos/v4/internal/api"
-	"github.com/redpanda-data/benthos/v4/internal/bundle"
 	"github.com/redpanda-data/benthos/v4/internal/component/metrics"
 	"github.com/redpanda-data/benthos/v4/internal/config"
 	"github.com/redpanda-data/benthos/v4/internal/docs"
@@ -60,13 +59,13 @@ func CreateManager(
 	tmpMgr.Version = cliOpts.Version
 
 	// Create our metrics type.
-	if stats, err = bundle.AllMetrics.Init(conf.Metrics, tmpMgr); err != nil {
+	if stats, err = cliOpts.Environment.MetricsInit(conf.Metrics, tmpMgr); err != nil {
 		err = fmt.Errorf("failed to connect to metrics aggregator: %w", err)
 		return
 	}
 
 	// Create our tracer type.
-	if trac, err = bundle.AllTracers.Init(conf.Tracer, tmpMgr); err != nil {
+	if trac, err = cliOpts.Environment.TracersInit(conf.Tracer, tmpMgr); err != nil {
 		err = fmt.Errorf("failed to initialise tracer: %w", err)
 		return
 	}
@@ -74,7 +73,7 @@ func CreateManager(
 	// Create HTTP API with a sanitised service config.
 	var sanitNode yaml.Node
 	if err = sanitNode.Encode(conf); err == nil {
-		sanitConf := docs.NewSanitiseConfig(bundle.GlobalEnvironment)
+		sanitConf := docs.NewSanitiseConfig(cliOpts.Environment)
 		sanitConf.RemoveTypeField = true
 		sanitConf.ScrubSecrets = true
 		sanitSpec := cliOpts.MainConfigSpecCtor()

--- a/internal/cli/common/opts.go
+++ b/internal/cli/common/opts.go
@@ -7,6 +7,7 @@ import (
 	"path"
 	"text/template"
 
+	"github.com/redpanda-data/benthos/v4/internal/bloblang"
 	"github.com/redpanda-data/benthos/v4/internal/bundle"
 	"github.com/redpanda-data/benthos/v4/internal/config"
 	"github.com/redpanda-data/benthos/v4/internal/docs"
@@ -25,8 +26,9 @@ type CLIOpts struct {
 	ShowRunCommand    bool
 	ConfigSearchPaths []string
 
-	Environment    *bundle.Environment
-	SecretAccessFn func(context.Context, string) (string, bool)
+	Environment      *bundle.Environment
+	BloblEnvironment *bloblang.Environment
+	SecretAccessFn   func(context.Context, string) (string, bool)
 
 	MainConfigSpecCtor   func() docs.FieldSpecs // TODO: This becomes a service.Environment
 	OnManagerInitialised func(mgr bundle.NewManagement, pConf *docs.ParsedConfig) error
@@ -51,7 +53,8 @@ func NewCLIOpts(version, dateBuilt string) *CLIOpts {
 			"/etc/benthos/config.yaml",
 			"/etc/benthos.yaml",
 		},
-		Environment: bundle.GlobalEnvironment,
+		Environment:      bundle.GlobalEnvironment,
+		BloblEnvironment: bloblang.GlobalEnvironment(),
 		SecretAccessFn: func(ctx context.Context, key string) (string, bool) {
 			return os.LookupEnv(key)
 		},

--- a/internal/cli/common/opts.go
+++ b/internal/cli/common/opts.go
@@ -2,6 +2,7 @@ package common
 
 import (
 	"bytes"
+	"context"
 	"os"
 	"path"
 	"text/template"
@@ -23,6 +24,9 @@ type CLIOpts struct {
 
 	ShowRunCommand    bool
 	ConfigSearchPaths []string
+
+	Environment    *bundle.Environment
+	SecretAccessFn func(context.Context, string) (string, bool)
 
 	MainConfigSpecCtor   func() docs.FieldSpecs // TODO: This becomes a service.Environment
 	OnManagerInitialised func(mgr bundle.NewManagement, pConf *docs.ParsedConfig) error
@@ -46,6 +50,10 @@ func NewCLIOpts(version, dateBuilt string) *CLIOpts {
 			"/benthos.yaml",
 			"/etc/benthos/config.yaml",
 			"/etc/benthos.yaml",
+		},
+		Environment: bundle.GlobalEnvironment,
+		SecretAccessFn: func(ctx context.Context, key string) (string, bool) {
+			return os.LookupEnv(key)
 		},
 		MainConfigSpecCtor: config.Spec,
 		OnManagerInitialised: func(mgr bundle.NewManagement, pConf *docs.ParsedConfig) error {

--- a/internal/cli/common/reader.go
+++ b/internal/cli/common/reader.go
@@ -30,5 +30,8 @@ func ReadConfig(c *cli.Context, cliOpts *CLIOpts, streamsMode bool) (mainPath st
 	if streamsMode {
 		opts = append(opts, config.OptSetStreamPaths(c.Args().Slice()...))
 	}
+	if cliOpts.SecretAccessFn != nil {
+		opts = append(opts, config.OptUseEnvLookupFunc(cliOpts.SecretAccessFn))
+	}
 	return path, inferred, config.NewReader(path, c.StringSlice("resources"), opts...)
 }

--- a/internal/cli/create.go
+++ b/internal/cli/create.go
@@ -168,7 +168,7 @@ If the expression is omitted a default config is created.`)[1:],
 
 			var node yaml.Node
 			if err = node.Encode(conf); err == nil {
-				sanitConf := docs.NewSanitiseConfig(bundle.GlobalEnvironment)
+				sanitConf := docs.NewSanitiseConfig(cliOpts.Environment)
 				sanitConf.RemoveTypeField = true
 				sanitConf.RemoveDeprecated = true
 				sanitConf.ForExample = true

--- a/internal/cli/lint.go
+++ b/internal/cli/lint.go
@@ -19,6 +19,7 @@ import (
 	"github.com/redpanda-data/benthos/v4/internal/docs"
 	ifilepath "github.com/redpanda-data/benthos/v4/internal/filepath"
 	"github.com/redpanda-data/benthos/v4/internal/filepath/ifs"
+	"github.com/redpanda-data/benthos/v4/public/bloblang"
 )
 
 var (
@@ -190,6 +191,7 @@ func LintAction(c *cli.Context, opts *common.CLIOpts, stderr io.Writer) int {
 	targets = append(targets, c.StringSlice("resources")...)
 
 	lConf := docs.NewLintConfig(opts.Environment)
+	lConf.BloblangEnv = bloblang.XWrapEnvironment(opts.BloblEnvironment)
 	lConf.RejectDeprecated = c.Bool("deprecated")
 	lConf.RequireLabels = c.Bool("labels")
 	skipEnvVarCheck := c.Bool("skip-env-var-check")

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -11,7 +11,6 @@ import (
 	"gopkg.in/yaml.v3"
 
 	"github.com/redpanda-data/benthos/v4/internal/bloblang/parser"
-	"github.com/redpanda-data/benthos/v4/internal/bundle"
 	"github.com/redpanda-data/benthos/v4/internal/cli/blobl"
 	"github.com/redpanda-data/benthos/v4/internal/cli/common"
 	"github.com/redpanda-data/benthos/v4/internal/cli/studio"
@@ -260,7 +259,7 @@ variables have been resolved:
 					}
 					var node yaml.Node
 					if err = node.Encode(pConf.Raw()); err == nil {
-						sanitConf := docs.NewSanitiseConfig(bundle.GlobalEnvironment)
+						sanitConf := docs.NewSanitiseConfig(opts.Environment)
 						sanitConf.RemoveTypeField = true
 						sanitConf.ScrubSecrets = true
 						err = opts.MainConfigSpecCtor().SanitiseYAML(&node, sanitConf)

--- a/internal/cli/test/cli.go
+++ b/internal/cli/test/cli.go
@@ -53,10 +53,10 @@ For more information check out the docs at:
 					fmt.Printf("Failed to init logger: %v\n", err)
 					os.Exit(1)
 				}
-				if RunAll(c.Args().Slice(), cliOpts.MainConfigSpecCtor(), "_benthos_test", true, logger, resourcesPaths) {
+				if RunAll(cliOpts, c.Args().Slice(), "_benthos_test", true, logger, resourcesPaths) {
 					os.Exit(0)
 				}
-			} else if RunAll(c.Args().Slice(), cliOpts.MainConfigSpecCtor(), "_benthos_test", true, log.Noop(), resourcesPaths) {
+			} else if RunAll(cliOpts, c.Args().Slice(), "_benthos_test", true, log.Noop(), resourcesPaths) {
 				os.Exit(0)
 			}
 			os.Exit(1)

--- a/internal/cli/test/command.go
+++ b/internal/cli/test/command.go
@@ -19,6 +19,7 @@ import (
 	ifilepath "github.com/redpanda-data/benthos/v4/internal/filepath"
 	"github.com/redpanda-data/benthos/v4/internal/filepath/ifs"
 	"github.com/redpanda-data/benthos/v4/internal/log"
+	"github.com/redpanda-data/benthos/v4/public/bloblang"
 )
 
 var (
@@ -103,12 +104,15 @@ func GetTestTargets(targetPaths []string, testSuffix string) (map[string][]test.
 func lintTarget(opts *common.CLIOpts, spec docs.FieldSpecs, path, testSuffix string) ([]docs.Lint, error) {
 	confPath, _ := GetPathPair(path, testSuffix)
 
+	lintConf := docs.NewLintConfig(opts.Environment)
+	lintConf.BloblangEnv = bloblang.XWrapEnvironment(opts.BloblEnvironment)
+
 	// This is necessary as each test case can provide a different set of
 	// environment variables, so in order to test env vars properly we would
 	// need to lint for each case.
 	skipEnvVarCheck := true
 	_, lints, err := config.NewReader("", nil, config.OptUseEnvLookupFunc(opts.SecretAccessFn)).
-		ReadYAMLFileLinted(context.TODO(), spec, confPath, skipEnvVarCheck, docs.NewLintConfig(opts.Environment))
+		ReadYAMLFileLinted(context.TODO(), spec, confPath, skipEnvVarCheck, lintConf)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/cli/test/command_test.go
+++ b/internal/cli/test/command_test.go
@@ -6,8 +6,8 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/redpanda-data/benthos/v4/internal/cli/common"
 	"github.com/redpanda-data/benthos/v4/internal/cli/test"
-	"github.com/redpanda-data/benthos/v4/internal/config"
 	"github.com/redpanda-data/benthos/v4/internal/log"
 )
 
@@ -245,15 +245,15 @@ tests:
 	}
 	defer os.RemoveAll(testDir)
 
-	if !test.RunAll([]string{filepath.Join(testDir, "foo.yaml")}, config.Spec(), "_benthos_test", false, log.Noop(), nil) {
+	if !test.RunAll(common.NewCLIOpts("", ""), []string{filepath.Join(testDir, "foo.yaml")}, "_benthos_test", false, log.Noop(), nil) {
 		t.Error("Unexpected result")
 	}
 
-	if test.RunAll([]string{filepath.Join(testDir, "foo.yaml")}, config.Spec(), "_benthos_test", true, log.Noop(), nil) {
+	if test.RunAll(common.NewCLIOpts("", ""), []string{filepath.Join(testDir, "foo.yaml")}, "_benthos_test", true, log.Noop(), nil) {
 		t.Error("Unexpected result")
 	}
 
-	if test.RunAll([]string{testDir}, config.Spec(), "_benthos_test", true, log.Noop(), nil) {
+	if test.RunAll(common.NewCLIOpts("", ""), []string{testDir}, "_benthos_test", true, log.Noop(), nil) {
 		t.Error("Unexpected result")
 	}
 }

--- a/internal/cli/test/definition.go
+++ b/internal/cli/test/definition.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"path/filepath"
 
+	"github.com/redpanda-data/benthos/v4/internal/bundle"
 	"github.com/redpanda-data/benthos/v4/internal/config/test"
 	"github.com/redpanda-data/benthos/v4/internal/docs"
 	"github.com/redpanda-data/benthos/v4/internal/filepath/ifs"
@@ -11,13 +12,8 @@ import (
 )
 
 // Execute the test definition.
-func Execute(confSpec docs.FieldSpecs, cases []test.Case, testFilePath string, resourcesPaths []string, logger log.Modular) ([]CaseFailure, error) {
-	procsProvider := NewProcessorsProvider(
-		testFilePath,
-		OptAddResourcesPaths(resourcesPaths),
-		OptProcessorsProviderSetLogger(logger),
-		OptSetConfigSpec(confSpec),
-	)
+func Execute(env *bundle.Environment, confSpec docs.FieldSpecs, cases []test.Case, testFilePath string, resourcesPaths []string, logger log.Modular) ([]CaseFailure, error) {
+	procsProvider := NewProcessorsProvider(testFilePath, resourcesPaths, confSpec, env, logger)
 
 	dir := filepath.Dir(testFilePath)
 

--- a/internal/cli/test/definition_test.go
+++ b/internal/cli/test/definition_test.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/fatih/color"
 
+	"github.com/redpanda-data/benthos/v4/internal/bundle"
 	"github.com/redpanda-data/benthos/v4/internal/cli/test"
 	"github.com/redpanda-data/benthos/v4/internal/config"
 	dtest "github.com/redpanda-data/benthos/v4/internal/config/test"
@@ -68,7 +69,7 @@ pipeline:
 		},
 	}
 
-	failures, err := test.Execute(config.Spec(), def, filepath.Join(testDir, "config1.yaml"), nil, log.Noop())
+	failures, err := test.Execute(bundle.GlobalEnvironment, config.Spec(), def, filepath.Join(testDir, "config1.yaml"), nil, log.Noop())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -152,7 +153,7 @@ pipeline:
 		},
 	}
 
-	failures, err := test.Execute(config.Spec(), def, filepath.Join(testDir, "config1.yaml"), nil, log.Noop())
+	failures, err := test.Execute(bundle.GlobalEnvironment, config.Spec(), def, filepath.Join(testDir, "config1.yaml"), nil, log.Noop())
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/config/env_vars_test.go
+++ b/internal/config/env_vars_test.go
@@ -1,6 +1,7 @@
 package config
 
 import (
+	"context"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -53,7 +54,10 @@ func TestEnvSwapping(t *testing.T) {
 	}
 
 	for in, exp := range tests {
-		out, err := ReplaceEnvVariables([]byte(in), envFn)
+		r := NewReader("", nil, OptUseEnvLookupFunc(func(ctx context.Context, s string) (string, bool) {
+			return envFn(s)
+		}))
+		out, err := r.ReplaceEnvVariables(context.Background(), []byte(in))
 		if exp.errContains != "" {
 			require.Error(t, err)
 			assert.Contains(t, err.Error(), exp.errContains)

--- a/internal/config/reader.go
+++ b/internal/config/reader.go
@@ -46,6 +46,9 @@ type Reader struct {
 	// The filesystem used for reading config files.
 	fs ifs.FS
 
+	// The function used for looking up environment variable interpolations.
+	envLookupFunc func(context.Context, string) (string, bool)
+
 	// Specs for various config types.
 	specFullConfig    docs.FieldSpecs
 	specStreamOnly    docs.FieldSpecs
@@ -92,8 +95,11 @@ func NewReader(mainPath string, resourcePaths []string, opts ...OptFunc) *Reader
 		mainPath = filepath.Clean(mainPath)
 	}
 	r := &Reader{
-		testSuffix:         "_benthos_test",
-		fs:                 ifs.OS(),
+		testSuffix: "_benthos_test",
+		fs:         ifs.OS(),
+		envLookupFunc: func(ctx context.Context, s string) (string, bool) {
+			return os.LookupEnv(s)
+		},
 		lintConf:           docs.NewLintConfig(bundle.GlobalEnvironment),
 		mainPath:           mainPath,
 		resourcePaths:      resourcePaths,
@@ -169,6 +175,13 @@ func OptSetStreamPaths(streamsPaths ...string) OptFunc {
 func OptUseFS(fs ifs.FS) OptFunc {
 	return func(r *Reader) {
 		r.fs = fs
+	}
+}
+
+// OptUseEnvLookupFunc overrides the default environment variable lookup func.
+func OptUseEnvLookupFunc(fn func(context.Context, string) (string, bool)) OptFunc {
+	return func(r *Reader) {
+		r.envLookupFunc = fn
 	}
 }
 
@@ -289,7 +302,7 @@ func (r *Reader) readMain(mainPath string) (conf Type, pConf *docs.ParsedConfig,
 	if mainPath != "" {
 		var dLints []docs.Lint
 		var modTime time.Time
-		if confBytes, dLints, modTime, err = ReadFileEnvSwap(r.fs, mainPath, os.LookupEnv); err != nil {
+		if confBytes, dLints, modTime, err = r.ReadFileEnvSwap(context.TODO(), mainPath); err != nil {
 			return
 		}
 		for _, l := range dLints {

--- a/internal/config/resource_reader.go
+++ b/internal/config/resource_reader.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io/fs"
-	"os"
 	"path/filepath"
 	"time"
 
@@ -208,7 +207,7 @@ func (r *Reader) readResource(path string) (conf manager.ResourceConfig, lints [
 	var confBytes []byte
 	var dLints []docs.Lint
 	var modTime time.Time
-	if confBytes, dLints, modTime, err = ReadFileEnvSwap(r.fs, path, os.LookupEnv); err != nil {
+	if confBytes, dLints, modTime, err = r.ReadFileEnvSwap(context.TODO(), path); err != nil {
 		return
 	}
 	for _, l := range dLints {

--- a/internal/config/stream_reader.go
+++ b/internal/config/stream_reader.go
@@ -2,10 +2,10 @@ package config
 
 import (
 	"bytes"
+	"context"
 	"errors"
 	"fmt"
 	"io/fs"
-	"os"
 	"path/filepath"
 	"strings"
 	"time"
@@ -47,7 +47,7 @@ func (r *Reader) readStreamFileConfig(path string) (conf stream.Config, lints []
 	var confBytes []byte
 	var dLints []docs.Lint
 	var modTime time.Time
-	if confBytes, dLints, modTime, err = ReadFileEnvSwap(r.fs, path, os.LookupEnv); err != nil {
+	if confBytes, dLints, modTime, err = r.ReadFileEnvSwap(context.TODO(), path); err != nil {
 		return
 	}
 	for _, l := range dLints {

--- a/internal/stream/manager/api.go
+++ b/internal/stream/manager/api.go
@@ -1,12 +1,12 @@
 package manager
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"io"
 	"net/http"
-	"os"
 	"strings"
 	"sync"
 
@@ -292,7 +292,7 @@ func (m *Type) HandleStreamCRUD(w http.ResponseWriter, r *http.Request) {
 
 		ignoreLints := r.URL.Query().Get("chilled") == "true"
 
-		if confBytes, err = config.ReplaceEnvVariables(confBytes, os.LookupEnv); err != nil {
+		if confBytes, err = config.NewReader("", nil).ReplaceEnvVariables(context.TODO(), confBytes); err != nil {
 			var errEnvMissing *config.ErrMissingEnvVars
 			if ignoreLints && errors.As(err, &errEnvMissing) {
 				confBytes = errEnvMissing.BestAttempt
@@ -529,7 +529,7 @@ func (m *Type) HandleResourceCRUD(w http.ResponseWriter, r *http.Request) {
 
 		ignoreLints := r.URL.Query().Get("chilled") == "true"
 
-		if confBytes, requestErr = config.ReplaceEnvVariables(confBytes, os.LookupEnv); requestErr != nil {
+		if confBytes, requestErr = config.NewReader("", nil).ReplaceEnvVariables(r.Context(), confBytes); requestErr != nil {
 			var errEnvMissing *config.ErrMissingEnvVars
 			if ignoreLints && errors.As(requestErr, &errEnvMissing) {
 				confBytes = errEnvMissing.BestAttempt

--- a/public/service/service.go
+++ b/public/service/service.go
@@ -5,6 +5,7 @@ import (
 	"log/slog"
 	"os"
 
+	"github.com/redpanda-data/benthos/v4/internal/bloblang"
 	"github.com/redpanda-data/benthos/v4/internal/bundle"
 	"github.com/redpanda-data/benthos/v4/internal/cli"
 	"github.com/redpanda-data/benthos/v4/internal/cli/common"
@@ -134,6 +135,17 @@ func CLIOptSetMainSchemaFrom(fn func() *ConfigSchema) CLIOptFunc {
 	}
 }
 
+// CLIOptSetEnvironmentFrom overrides the default Benthos plugin environment for
+// another.
+func CLIOptSetEnvironment(e *Environment) CLIOptFunc {
+	return func(c *CLIOptBuilder) {
+		c.opts.Environment = e.internal
+		c.opts.BloblEnvironment = e.bloblangEnv.XUnwrapper().(interface {
+			Unwrap() *bloblang.Environment
+		}).Unwrap()
+	}
+}
+
 // CLIOptOnConfigParse sets a closure function to be called when a main
 // configuration file load has occurred.
 //
@@ -147,5 +159,15 @@ func CLIOptOnConfigParse(fn func(fn *ParsedConfig) error) CLIOptFunc {
 				mgr: mgr,
 			})
 		}
+	}
+}
+
+// CLIOptSetEnvVarLookup overrides the default environment variable lookup
+// function for config interpolation functions, this allows custom secret
+// mechanisms to be referenced as an alternative, or in combination with,
+// environment variables.
+func CLIOptSetEnvVarLookup(fn func(context.Context, string) (string, bool)) CLIOptFunc {
+	return func(c *CLIOptBuilder) {
+		c.opts.SecretAccessFn = fn
 	}
 }

--- a/public/service/service.go
+++ b/public/service/service.go
@@ -135,7 +135,7 @@ func CLIOptSetMainSchemaFrom(fn func() *ConfigSchema) CLIOptFunc {
 	}
 }
 
-// CLIOptSetEnvironmentFrom overrides the default Benthos plugin environment for
+// CLIOptSetEnvironment overrides the default Benthos plugin environment for
 // another.
 func CLIOptSetEnvironment(e *Environment) CLIOptFunc {
 	return func(c *CLIOptBuilder) {

--- a/public/service/stream_builder.go
+++ b/public/service/stream_builder.go
@@ -996,7 +996,9 @@ func (s *StreamBuilder) buildConfig() builderConfig {
 
 func (s *StreamBuilder) getYAMLNode(b []byte) (*yaml.Node, error) {
 	var err error
-	if b, err = config.ReplaceEnvVariables(b, s.envVarLookupFn); err != nil {
+	if b, err = config.NewReader("", nil, config.OptUseEnvLookupFunc(func(ctx context.Context, key string) (string, bool) {
+		return s.envVarLookupFn(key)
+	})).ReplaceEnvVariables(context.TODO(), b); err != nil {
 		// TODO: Allow users to specify whether they care about env variables
 		// missing, in which case we error or not based on that.
 		var errEnvMissing *config.ErrMissingEnvVars

--- a/public/service/stream_config_linter.go
+++ b/public/service/stream_config_linter.go
@@ -77,7 +77,9 @@ func (s *StreamConfigLinter) LintYAML(yamlBytes []byte) (lints []Lint, err error
 		})
 	}
 
-	if yamlBytes, err = config.ReplaceEnvVariables(yamlBytes, s.envVarLookupFn); err != nil {
+	if yamlBytes, err = config.NewReader("", nil, config.OptUseEnvLookupFunc(func(ctx context.Context, key string) (string, bool) {
+		return s.envVarLookupFn(key)
+	})).ReplaceEnvVariables(context.TODO(), yamlBytes); err != nil {
 		var errEnvMissing *config.ErrMissingEnvVars
 		if !errors.As(err, &errEnvMissing) {
 			return


### PR DESCRIPTION
This PR adds two new options for the public CLI API, the first sets a custom environment to be used for parsing and executing configs. This will allow builds to customise exactly which plugins are available. The second is a custom function for obtaining interpolated environment variables within configs, this allows builds to customise where those values of taken from.