### PR TITLE
Generic plugin resources

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 - Field `max_retries` added to the `retry` processor. (@mihaitodor)
 - Metadata fields `retry_count` and `backoff_duration` added to the `retry` processor. (@mihaitodor)
 - Parameter `escape_html` added to the `format_json()` Bloblang method. (@mihaitodor)
+- Go API: New generic key/value store methods added to the `*Resources` type. (@Jeffail)
 
 ## 4.30.0 - 2024-06-13
 

--- a/internal/bundle/package.go
+++ b/internal/bundle/package.go
@@ -95,6 +95,7 @@ type NewManagement interface {
 	UnsetPipe(name string, t <-chan message.Transaction)
 
 	GetGeneric(key any) (any, bool)
+	GetOrSetGeneric(key, value any) (actual any, loaded bool)
 	SetGeneric(key, value any)
 }
 

--- a/internal/bundle/package.go
+++ b/internal/bundle/package.go
@@ -93,6 +93,9 @@ type NewManagement interface {
 	GetPipe(name string) (<-chan message.Transaction, error)
 	SetPipe(name string, t <-chan message.Transaction)
 	UnsetPipe(name string, t <-chan message.Transaction)
+
+	GetGeneric(key any) (any, bool)
+	SetGeneric(key, value any)
 }
 
 type componentErr struct {

--- a/internal/manager/mock/manager.go
+++ b/internal/manager/mock/manager.go
@@ -37,6 +37,8 @@ type Manager struct {
 	Pipes      map[string]<-chan message.Transaction
 	lock       sync.Mutex
 
+	genericValues *sync.Map
+
 	// OnRegisterEndpoint can be set in order to intercept endpoints registered
 	// by components.
 	OnRegisterEndpoint func(path string, h http.HandlerFunc)
@@ -50,17 +52,18 @@ type Manager struct {
 // NewManager provides a new mock manager.
 func NewManager() *Manager {
 	return &Manager{
-		Version:    "mock",
-		Inputs:     map[string]*Input{},
-		Caches:     map[string]map[string]CacheItem{},
-		RateLimits: map[string]RateLimit{},
-		Outputs:    map[string]OutputWriter{},
-		Processors: map[string]Processor{},
-		Pipes:      map[string]<-chan message.Transaction{},
-		CustomFS:   ifs.OS(),
-		M:          metrics.Noop(),
-		L:          log.Noop(),
-		T:          noop.NewTracerProvider(),
+		Version:       "mock",
+		Inputs:        map[string]*Input{},
+		Caches:        map[string]map[string]CacheItem{},
+		RateLimits:    map[string]RateLimit{},
+		Outputs:       map[string]OutputWriter{},
+		Processors:    map[string]Processor{},
+		Pipes:         map[string]<-chan message.Transaction{},
+		CustomFS:      ifs.OS(),
+		M:             metrics.Noop(),
+		L:             log.Noop(),
+		T:             noop.NewTracerProvider(),
+		genericValues: &sync.Map{},
 	}
 }
 
@@ -370,4 +373,14 @@ func (m *Manager) SetPipe(name string, t <-chan message.Transaction) {
 // UnsetPipe removes a named transaction chan.
 func (m *Manager) UnsetPipe(name string, t <-chan message.Transaction) {
 	delete(m.Pipes, name)
+}
+
+// GetGeneric attempts to obtain and return a generic resource value by key.
+func (m *Manager) GetGeneric(key any) (any, bool) {
+	return m.genericValues.Load(key)
+}
+
+// SetGeneric attempts to set a generic resource to a given value by key.
+func (m *Manager) SetGeneric(key, value any) {
+	m.genericValues.Store(key, value)
 }

--- a/internal/manager/mock/manager.go
+++ b/internal/manager/mock/manager.go
@@ -380,6 +380,13 @@ func (m *Manager) GetGeneric(key any) (any, bool) {
 	return m.genericValues.Load(key)
 }
 
+// GetOrSetGeneric attempts to obtain an existing value for a given key if
+// present. Otherwise, it stores and returns the provided value. The loaded
+// result is true if the value was loaded, false if stored.
+func (m *Manager) GetOrSetGeneric(key, value any) (actual any, loaded bool) {
+	return m.genericValues.LoadOrStore(key, value)
+}
+
 // SetGeneric attempts to set a generic resource to a given value by key.
 func (m *Manager) SetGeneric(key, value any) {
 	m.genericValues.Store(key, value)

--- a/internal/manager/type.go
+++ b/internal/manager/type.go
@@ -92,6 +92,9 @@ type Type struct {
 
 	pipes    map[string]<-chan message.Transaction
 	pipeLock *sync.RWMutex
+
+	// Generic key/value store for plugin implementations.
+	genericResources *sync.Map
 }
 
 // OptFunc is an opt setting for a manager type.
@@ -204,6 +207,8 @@ func New(conf ResourceConfig, opts ...OptFunc) (*Type, error) {
 
 		pipes:    map[string]<-chan message.Transaction{},
 		pipeLock: &sync.RWMutex{},
+
+		genericResources: &sync.Map{},
 	}
 
 	for _, opt := range opts {
@@ -412,6 +417,16 @@ func (t *Type) UnsetPipe(name string, tran <-chan message.Transaction) {
 		delete(t.pipes, name)
 	}
 	t.pipeLock.Unlock()
+}
+
+// GetGeneric attempts to obtain and return a generic resource value by key.
+func (t *Type) GetGeneric(key any) (any, bool) {
+	return t.genericResources.Load(key)
+}
+
+// SetGeneric attempts to set a generic resource to a given value by key.
+func (t *Type) SetGeneric(key, value any) {
+	t.genericResources.Store(key, value)
 }
 
 //------------------------------------------------------------------------------

--- a/internal/manager/type.go
+++ b/internal/manager/type.go
@@ -94,7 +94,7 @@ type Type struct {
 	pipeLock *sync.RWMutex
 
 	// Generic key/value store for plugin implementations.
-	genericResources *sync.Map
+	genericValues *sync.Map
 }
 
 // OptFunc is an opt setting for a manager type.
@@ -208,7 +208,7 @@ func New(conf ResourceConfig, opts ...OptFunc) (*Type, error) {
 		pipes:    map[string]<-chan message.Transaction{},
 		pipeLock: &sync.RWMutex{},
 
-		genericResources: &sync.Map{},
+		genericValues: &sync.Map{},
 	}
 
 	for _, opt := range opts {
@@ -421,12 +421,19 @@ func (t *Type) UnsetPipe(name string, tran <-chan message.Transaction) {
 
 // GetGeneric attempts to obtain and return a generic resource value by key.
 func (t *Type) GetGeneric(key any) (any, bool) {
-	return t.genericResources.Load(key)
+	return t.genericValues.Load(key)
+}
+
+// GetOrSetGeneric attempts to obtain an existing value for a given key if
+// present. Otherwise, it stores and returns the provided value. The loaded
+// result is true if the value was loaded, false if stored.
+func (t *Type) GetOrSetGeneric(key, value any) (actual any, loaded bool) {
+	return t.genericValues.LoadOrStore(key, value)
 }
 
 // SetGeneric attempts to set a generic resource to a given value by key.
 func (t *Type) SetGeneric(key, value any) {
-	t.genericResources.Store(key, value)
+	t.genericValues.Store(key, value)
 }
 
 //------------------------------------------------------------------------------

--- a/internal/manager/type_test.go
+++ b/internal/manager/type_test.go
@@ -564,3 +564,16 @@ func TestManagerGenericResources(t *testing.T) {
 	assert.True(t, exists)
 	assert.Equal(t, "bar", v)
 }
+
+func TestManagerGenericGetOrSet(t *testing.T) {
+	mgr, err := manager.New(manager.NewResourceConfig())
+	require.NoError(t, err)
+
+	v, loaded := mgr.GetOrSetGeneric(testKeyA, "foo")
+	assert.False(t, loaded)
+	assert.Equal(t, "foo", v)
+
+	v, loaded = mgr.GetOrSetGeneric(testKeyA, "bar")
+	assert.True(t, loaded)
+	assert.Equal(t, "foo", v)
+}

--- a/internal/manager/type_test.go
+++ b/internal/manager/type_test.go
@@ -539,3 +539,28 @@ func TestManagerPipeGetSet(t *testing.T) {
 		t.Error("Wrong transaction chan returned")
 	}
 }
+
+type testKeyTypeA int
+type testKeyTypeB int
+
+const testKeyA testKeyTypeA = iota
+const testKeyB testKeyTypeB = iota
+
+func TestManagerGenericResources(t *testing.T) {
+	mgr, err := manager.New(manager.NewResourceConfig())
+	require.NoError(t, err)
+
+	mgr.SetGeneric(testKeyA, "foo")
+	mgr.SetGeneric(testKeyB, "bar")
+
+	_, exists := mgr.GetGeneric("not a key")
+	assert.False(t, exists)
+
+	v, exists := mgr.GetGeneric(testKeyA)
+	assert.True(t, exists)
+	assert.Equal(t, "foo", v)
+
+	v, exists = mgr.GetGeneric(testKeyB)
+	assert.True(t, exists)
+	assert.Equal(t, "bar", v)
+}

--- a/public/service/resources.go
+++ b/public/service/resources.go
@@ -250,6 +250,31 @@ func (r *Resources) HasRateLimit(name string) bool {
 	return r.mgr.ProbeRateLimit(name)
 }
 
+// GetGeneric queries the resources for a generic key value, potentially set by
+// another plugin or instantiation of this plugin.
+func (r *Resources) GetGeneric(key any) (any, bool) {
+	return r.mgr.GetGeneric(key)
+}
+
+// GetOrSetGeneric attempts to obtain an existing generic value for a given key
+// if present. Otherwise, it stores and returns the provided value. The loaded
+// result is true if the value was loaded, false if stored.
+func (r *Resources) GetOrSetGeneric(key, value any) (actual any, loaded bool) {
+	return r.mgr.GetOrSetGeneric(key, value)
+}
+
+// SetGeneric sets a generic key/value pair, which can be accessed by other
+// plugin implementations with access to the same resources.
+//
+// The provided key must be comparable and should not be of type string or any
+// other built-in type to avoid collisions between packages using resources.
+// Users of SetGeneric should define their own types for keys. To avoid
+// allocating when assigning to an any type, keys often have concrete type
+// struct{}.
+func (r *Resources) SetGeneric(key, value any) {
+	r.mgr.SetGeneric(key, value)
+}
+
 //------------------------------------------------------------------------------
 
 type resourcesUnwrapper struct {

--- a/public/service/resources_test.go
+++ b/public/service/resources_test.go
@@ -150,3 +150,39 @@ output:
 {"id":3,"purpose":"test resource outputs"}
 `, string(outBytes))
 }
+
+type testKeyTypeA int
+type testKeyTypeB int
+
+const testKeyA testKeyTypeA = iota
+const testKeyB testKeyTypeB = iota
+
+func TestResourcesGenericValues(t *testing.T) {
+	res := service.MockResources()
+
+	res.SetGeneric(testKeyA, "foo")
+	res.SetGeneric(testKeyB, "bar")
+
+	_, exists := res.GetGeneric("not a key")
+	assert.False(t, exists)
+
+	v, exists := res.GetGeneric(testKeyA)
+	assert.True(t, exists)
+	assert.Equal(t, "foo", v)
+
+	v, exists = res.GetGeneric(testKeyB)
+	assert.True(t, exists)
+	assert.Equal(t, "bar", v)
+}
+
+func TestResourcesGenericGetOrSet(t *testing.T) {
+	res := service.MockResources()
+
+	v, loaded := res.GetOrSetGeneric(testKeyA, "foo")
+	assert.False(t, loaded)
+	assert.Equal(t, "foo", v)
+
+	v, loaded = res.GetOrSetGeneric(testKeyA, "bar")
+	assert.True(t, loaded)
+	assert.Equal(t, "foo", v)
+}


### PR DESCRIPTION
This PR adds some public methods to the `*Resources` type that allows plugin authors to define shared values across plugin instanciations within a given resource ecosystem. These generic values are worth using above a global singleton as they respect the isolation of a given execution environment.