### PR TITLE
Fix docs typo in `Processor.Process()`

### DIFF
--- a/public/service/processor.go
+++ b/public/service/processor.go
@@ -21,7 +21,7 @@ type Processor interface {
 	// with the patterns outlined in https://docs.redpanda.com/redpanda-connect/configuration/error_handling.
 	//
 	// The Message types returned MUST be derived from the provided message, and
-	// CANNOT be custom implementations of Message. In order to copy the
+	// CANNOT be custom instantiations of Message. In order to copy the
 	// provided message use the Copy method.
 	Process(context.Context, *Message) (MessageBatch, error)
 
@@ -53,7 +53,7 @@ type BatchProcessor interface {
 	// with a nil error.
 	//
 	// The Message types returned MUST be derived from the provided messages,
-	// and CANNOT be custom implementations of Message. In order to copy the
+	// and CANNOT be custom instantiations of Message. In order to copy the
 	// provided messages use the Copy method.
 	ProcessBatch(context.Context, MessageBatch) ([]MessageBatch, error)
 


### PR DESCRIPTION
Also in `BatchProcessor.ProcessBatch()`.

According to Ash:

> You need to ensure that if you end up yielding N messages then you need to copy the original message N times rather than create N new instantiations. That's because we use the context from the original message to carry things like distributed tracing info and synchronous response mechanisms.