### PR TITLE
Improve CLI package testability

### DIFF
--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -4,7 +4,6 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"os"
 	"runtime/debug"
 	"strings"
 
@@ -133,15 +132,15 @@ Either run {{.ProductName}} as a stream processor or choose a command:
 		},
 		Action: func(c *cli.Context) error {
 			if c.Bool("version") {
-				fmt.Printf("Version: %v\nDate: %v\n", opts.Version, opts.DateBuilt)
+				fmt.Fprintf(opts.Stdout, "Version: %v\nDate: %v\n", opts.Version, opts.DateBuilt)
 				return nil
 			}
 			if c.Bool("help-autocomplete") {
-				_ = json.NewEncoder(os.Stdout).Encode(traverseHelp(c.Command, nil))
+				_ = json.NewEncoder(opts.Stdout).Encode(traverseHelp(c.Command, nil))
 				return nil
 			}
 			if c.Args().Len() > 0 {
-				fmt.Fprintf(os.Stderr, "Unrecognised command: %v\n", c.Args().First())
+				fmt.Fprintf(opts.Stderr, "Unrecognised command: %v\n", c.Args().First())
 				_ = cli.ShowAppHelp(c)
 				return &common.ErrExitCode{Err: errors.New("unrecognised command"), Code: 1}
 			}
@@ -163,7 +162,7 @@ Either run {{.ProductName}} as a stream processor or choose a command:
 	}
 
 	app.OnUsageError = func(context *cli.Context, err error, isSubcommand bool) error {
-		fmt.Printf("Usage error: %v\n", err)
+		fmt.Fprintf(opts.Stdout, "Usage error: %v\n", err)
 		_ = cli.ShowAppHelp(context)
 		return err
 	}

--- a/internal/cli/app.go
+++ b/internal/cli/app.go
@@ -2,6 +2,7 @@ package cli
 
 import (
 	"encoding/json"
+	"errors"
 	"fmt"
 	"os"
 	"runtime/debug"
@@ -133,22 +134,19 @@ Either run {{.ProductName}} as a stream processor or choose a command:
 		Action: func(c *cli.Context) error {
 			if c.Bool("version") {
 				fmt.Printf("Version: %v\nDate: %v\n", opts.Version, opts.DateBuilt)
-				os.Exit(0)
+				return nil
 			}
 			if c.Bool("help-autocomplete") {
 				_ = json.NewEncoder(os.Stdout).Encode(traverseHelp(c.Command, nil))
-				os.Exit(0)
+				return nil
 			}
 			if c.Args().Len() > 0 {
 				fmt.Fprintf(os.Stderr, "Unrecognised command: %v\n", c.Args().First())
 				_ = cli.ShowAppHelp(c)
-				os.Exit(1)
+				return &common.ErrExitCode{Err: errors.New("unrecognised command"), Code: 1}
 			}
 
-			if code := common.RunService(c, opts, false); code != 0 {
-				os.Exit(code)
-			}
-			return nil
+			return common.RunService(c, opts, false)
 		},
 		Commands: []*cli.Command{
 			echoCliCommand(opts),

--- a/internal/cli/app_test.go
+++ b/internal/cli/app_test.go
@@ -3,6 +3,7 @@ package cli_test
 import (
 	"context"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"testing"
@@ -37,7 +38,10 @@ output:
 	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(time.Second))
 	defer cancel()
 
-	require.NoError(t, icli.App(common.NewCLIOpts("1.2.3", "aaa")).RunContext(ctx, []string{"benthos", "-c", confPath}))
+	opts := common.NewCLIOpts("1.2.3", "aaa")
+	opts.Stdout = io.Discard
+
+	require.NoError(t, icli.App(opts).RunContext(ctx, []string{"benthos", "-c", confPath}))
 
 	data, _ := os.ReadFile(outPath)
 	assert.Contains(t, string(data), "foobar")

--- a/internal/cli/blobl/cli.go
+++ b/internal/cli/blobl/cli.go
@@ -64,7 +64,9 @@ Find out more about Bloblang at: {{.DocumentationURL}}/guides/bloblang/about`)[1
 				Value: bufio.MaxScanTokenSize,
 			},
 		},
-		Action: run,
+		Action: func(ctx *cli.Context) error {
+			return run(ctx, opts)
+		},
 		Subcommands: []*cli.Command{
 			{
 				Name:  "server",
@@ -217,7 +219,7 @@ func (e *execCache) executeMapping(exec *mapping.Executor, rawInput, prettyOutpu
 	return resultStr, nil
 }
 
-func run(c *cli.Context) error {
+func run(c *cli.Context, opts *common.CLIOpts) error {
 	t := c.Int("threads")
 	if t < 1 {
 		t = 1
@@ -266,7 +268,7 @@ func run(c *cli.Context) error {
 	resultsChan := make(chan string)
 	go func() {
 		for res := range resultsChan {
-			fmt.Println(res)
+			fmt.Fprintln(opts.Stdout, res)
 		}
 	}()
 
@@ -281,7 +283,7 @@ func run(c *cli.Context) error {
 
 				resultStr, err := execCache.executeMapping(exec, raw, pretty, input)
 				if err != nil {
-					fmt.Fprintln(os.Stderr, red(fmt.Sprintf("failed to execute map: %v", err)))
+					fmt.Fprintln(opts.Stderr, red(fmt.Sprintf("failed to execute map: %v", err)))
 					continue
 				}
 				resultsChan <- resultStr

--- a/internal/cli/common/logger.go
+++ b/internal/cli/common/logger.go
@@ -1,7 +1,6 @@
 package common
 
 import (
-	"os"
 	"strings"
 
 	"github.com/urfave/cli/v2"
@@ -17,9 +16,9 @@ func CreateLogger(c *cli.Context, opts *CLIOpts, conf config.Type, streamsMode b
 		conf.Logger.LogLevel = strings.ToUpper(overrideLogLevel)
 	}
 
-	defaultStream := os.Stdout
+	defaultStream := opts.Stdout
 	if !streamsMode && conf.Output.Type == "stdout" {
-		defaultStream = os.Stderr
+		defaultStream = opts.Stderr
 	}
 	if logger, err = log.New(defaultStream, ifs.OS(), conf.Logger); err != nil {
 		return

--- a/internal/cli/common/manager.go
+++ b/internal/cli/common/manager.go
@@ -123,6 +123,7 @@ func CreateManager(
 // stopped according to the configured shutdown timeout.
 func RunManagerUntilStopped(
 	c *cli.Context,
+	opts *CLIOpts,
 	conf config.Type,
 	stopMgr *StoppableManager,
 	stopStrm Stoppable,
@@ -159,7 +160,7 @@ func RunManagerUntilStopped(
 				"Service failed to close cleanly within allocated time." +
 					" Exiting forcefully and dumping stack trace to stderr",
 			)
-			_ = pprof.Lookup("goroutine").WriteTo(os.Stderr, 1)
+			_ = pprof.Lookup("goroutine").WriteTo(opts.Stderr, 1)
 			os.Exit(1)
 		}()
 
@@ -175,7 +176,7 @@ func RunManagerUntilStopped(
 				"Service failed to close resources cleanly within allocated time: %v."+
 					" Exiting forcefully and dumping stack trace to stderr\n", err,
 			)
-			_ = pprof.Lookup("goroutine").WriteTo(os.Stderr, 1)
+			_ = pprof.Lookup("goroutine").WriteTo(opts.Stderr, 1)
 			return
 		}
 	}()

--- a/internal/cli/common/opts.go
+++ b/internal/cli/common/opts.go
@@ -3,6 +3,7 @@ package common
 import (
 	"bytes"
 	"context"
+	"io"
 	"os"
 	"path"
 	"text/template"
@@ -17,6 +18,9 @@ import (
 // CLIOpts contains the available CLI configuration options.
 type CLIOpts struct {
 	RootFlags *RootCommonFlags
+
+	Stdout io.Writer
+	Stderr io.Writer
 
 	Version   string
 	DateBuilt string
@@ -44,6 +48,8 @@ func NewCLIOpts(version, dateBuilt string) *CLIOpts {
 	}
 	return &CLIOpts{
 		RootFlags:        &RootCommonFlags{},
+		Stdout:           os.Stdout,
+		Stderr:           os.Stderr,
 		Version:          version,
 		DateBuilt:        dateBuilt,
 		BinaryName:       binaryName,

--- a/internal/cli/common/run_flags.go
+++ b/internal/cli/common/run_flags.go
@@ -194,7 +194,7 @@ func PreApplyEnvFilesAndTemplates(c *cli.Context, opts *CLIOpts) error {
 	}
 	if !opts.RootFlags.GetChilled(c) && len(lints) > 0 {
 		for _, lint := range lints {
-			fmt.Fprintln(os.Stderr, lint)
+			fmt.Fprintln(opts.Stderr, lint)
 		}
 		return errors.New(opts.ExecTemplate("Shutting down due to linter errors, to prevent shutdown run {{.ProductName}} with --chilled"))
 	}

--- a/internal/cli/common/service.go
+++ b/internal/cli/common/service.go
@@ -98,7 +98,7 @@ func RunService(c *cli.Context, cliOpts *CLIOpts, streamsMode bool) error {
 		return err
 	}
 
-	return RunManagerUntilStopped(c, conf, stoppableManager, stoppableStream, dataStreamClosedChan)
+	return RunManagerUntilStopped(c, cliOpts, conf, stoppableManager, stoppableStream, dataStreamClosedChan)
 }
 
 // DelayShutdown attempts to block until either:

--- a/internal/cli/create.go
+++ b/internal/cli/create.go
@@ -179,7 +179,7 @@ If the expression is omitted a default config is created.`)[1:],
 			if err == nil {
 				var configYAML []byte
 				if configYAML, err = docs.MarshalYAML(node); err == nil {
-					fmt.Println(string(configYAML))
+					fmt.Fprintln(cliOpts.Stdout, string(configYAML))
 				}
 			}
 			if err != nil {

--- a/internal/cli/create.go
+++ b/internal/cli/create.go
@@ -3,7 +3,6 @@ package cli
 import (
 	"errors"
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/urfave/cli/v2"
@@ -147,8 +146,7 @@ If the expression is omitted a default config is created.`)[1:],
 			}
 			if expression := c.Args().First(); expression != "" {
 				if err := addExpression(conf, expression); err != nil {
-					fmt.Fprintf(os.Stderr, "Generate error: %v\n", err)
-					os.Exit(1)
+					return fmt.Errorf("generate error: %w", err)
 				}
 			}
 
@@ -165,8 +163,7 @@ If the expression is omitted a default config is created.`)[1:],
 				FallbackToAny: true,
 			})
 			if err != nil {
-				fmt.Fprintf(os.Stderr, "Generate error: %v\n", err)
-				os.Exit(1)
+				return fmt.Errorf("generate error: %w", err)
 			}
 
 			var node yaml.Node
@@ -186,8 +183,7 @@ If the expression is omitted a default config is created.`)[1:],
 				}
 			}
 			if err != nil {
-				fmt.Fprintf(os.Stderr, "Generate error: %v\n", err)
-				os.Exit(1)
+				return fmt.Errorf("generate error: %w", err)
 			}
 			return nil
 		},

--- a/internal/cli/create_test.go
+++ b/internal/cli/create_test.go
@@ -1,0 +1,89 @@
+package cli_test
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/redpanda-data/benthos/v4/internal/cli"
+	"github.com/redpanda-data/benthos/v4/internal/cli/common"
+	_ "github.com/redpanda-data/benthos/v4/public/components/io"
+	_ "github.com/redpanda-data/benthos/v4/public/components/pure"
+)
+
+func TestCreate(t *testing.T) {
+	tests := []struct {
+		name        string
+		args        []string
+		contains    []string
+		notContains []string
+	}{
+		{
+			name: "create no arguments",
+			args: []string{"benthos", "create"},
+			contains: []string{
+				"http:",
+				"stdout:",
+				"stdin:",
+				"logger:",
+			},
+		},
+		{
+			name: "create single components",
+			args: []string{"benthos", "create", "file/mapping/http_client"},
+			contains: []string{
+				"file:",
+				"mapping:",
+				"http_client:",
+			},
+		},
+		{
+			name: "create multiple components",
+			args: []string{"benthos", "create", "file,http_server/mapping,http/http_client,stdout"},
+			contains: []string{
+				"file:",
+				"http_server:",
+				"mapping:",
+				"http:",
+				"http_client:",
+				"stdout:",
+			},
+		},
+		{
+			name: "create simple",
+			args: []string{"benthos", "create", "-s"},
+			contains: []string{
+				"stdout:",
+				"stdin:",
+			},
+			notContains: []string{
+				"http:",
+				"logger:",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			var stdout, stderr bytes.Buffer
+
+			opts := common.NewCLIOpts("", "")
+			opts.Stdout = &stdout
+			opts.Stderr = &stderr
+
+			err := cli.App(opts).Run(test.args)
+			require.NoError(t, err)
+
+			for _, exp := range test.contains {
+				assert.Contains(t, stdout.String(), exp)
+			}
+
+			for _, exp := range test.notContains {
+				assert.NotContains(t, stdout.String(), exp)
+			}
+		})
+	}
+}

--- a/internal/cli/echo.go
+++ b/internal/cli/echo.go
@@ -1,8 +1,8 @@
 package cli
 
 import (
+	"errors"
 	"fmt"
-	"os"
 
 	"github.com/urfave/cli/v2"
 	"gopkg.in/yaml.v3"
@@ -45,8 +45,7 @@ variables have been resolved:
 		Action: func(c *cli.Context) error {
 			if c.Args().Len() > 0 {
 				if c.Args().Len() > 1 {
-					fmt.Fprintln(os.Stderr, "A maximum of one config must be specified with the echo command")
-					os.Exit(1)
+					return errors.New("a maximum of one config must be specified with the echo command")
 				}
 				opts.RootFlags.Config = c.Args().First()
 			}
@@ -54,8 +53,7 @@ variables have been resolved:
 			_, _, confReader := common.ReadConfig(c, opts, false)
 			_, pConf, _, err := confReader.Read()
 			if err != nil {
-				fmt.Fprintf(os.Stderr, "Configuration file read error: %v\n", err)
-				os.Exit(1)
+				return fmt.Errorf("configuration file read error: %w", err)
 			}
 			var node yaml.Node
 			if err = node.Encode(pConf.Raw()); err == nil {
@@ -71,8 +69,7 @@ variables have been resolved:
 				}
 			}
 			if err != nil {
-				fmt.Fprintf(os.Stderr, "Echo error: %v\n", err)
-				os.Exit(1)
+				return fmt.Errorf("echo error: %w", err)
 			}
 			return nil
 		},

--- a/internal/cli/echo.go
+++ b/internal/cli/echo.go
@@ -65,7 +65,7 @@ variables have been resolved:
 			if err == nil {
 				var configYAML []byte
 				if configYAML, err = docs.MarshalYAML(node); err == nil {
-					fmt.Println(string(configYAML))
+					fmt.Fprintln(opts.Stdout, string(configYAML))
 				}
 			}
 			if err != nil {

--- a/internal/cli/echo_test.go
+++ b/internal/cli/echo_test.go
@@ -1,0 +1,97 @@
+package cli_test
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/redpanda-data/benthos/v4/internal/cli"
+	"github.com/redpanda-data/benthos/v4/internal/cli/common"
+	_ "github.com/redpanda-data/benthos/v4/public/components/io"
+	_ "github.com/redpanda-data/benthos/v4/public/components/pure"
+)
+
+func TestEcho(t *testing.T) {
+	tmpDir := t.TempDir()
+	tFile := func(name string) string {
+		return filepath.Join(tmpDir, name)
+	}
+
+	tests := []struct {
+		name     string
+		files    map[string]string
+		args     []string
+		contains []string
+	}{
+		{
+			name: "echo single file",
+			args: []string{"benthos", "echo", tFile("foo.yaml")},
+			files: map[string]string{
+				"foo.yaml": `
+input:
+  generate:
+    mapping: 'root.id = uuid_v4()'
+output:
+  drop: {}
+`,
+			},
+			contains: []string{
+				"generate:",
+				"root.id = uuid_v4",
+				"drop: {}",
+			},
+		},
+		{
+			name: "echo single file old style",
+			args: []string{"benthos", "-c", tFile("foo.yaml"), "echo"},
+			files: map[string]string{
+				"foo.yaml": `
+input:
+  generate:
+    mapping: 'root.id = uuid_v4()'
+output:
+  drop: {}
+`,
+			},
+			contains: []string{
+				"generate:",
+				"root.id = uuid_v4",
+				"drop: {}",
+			},
+		},
+		{
+			name: "echo with set flag",
+			args: []string{"benthos", "echo", "--set", `input.generate.mapping=root.id = uuid_v4()`},
+			contains: []string{
+				"generate:",
+				"root.id = uuid_v4",
+			},
+		},
+	}
+
+	for _, test := range tests {
+		test := test
+		t.Run(test.name, func(t *testing.T) {
+			for name, c := range test.files {
+				require.NoError(t, os.WriteFile(tFile(name), []byte(c), 0o644))
+			}
+
+			var stdout, stderr bytes.Buffer
+
+			opts := common.NewCLIOpts("", "")
+			opts.Stdout = &stdout
+			opts.Stderr = &stderr
+
+			err := cli.App(opts).Run(test.args)
+			require.NoError(t, err)
+
+			for _, exp := range test.contains {
+				assert.Contains(t, stdout.String(), exp)
+			}
+		})
+	}
+}

--- a/internal/cli/lint.go
+++ b/internal/cli/lint.go
@@ -6,7 +6,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"os"
 	"path"
 	"runtime"
 	"sync"
@@ -66,7 +65,7 @@ files with the .yaml or .yml extension.`)[1:],
 			return common.PreApplyEnvFilesAndTemplates(c, cliOpts)
 		},
 		Action: func(c *cli.Context) error {
-			return LintAction(c, cliOpts, os.Stderr)
+			return LintAction(c, cliOpts, cliOpts.Stderr)
 		},
 	}
 }

--- a/internal/cli/lint.go
+++ b/internal/cli/lint.go
@@ -66,10 +66,7 @@ files with the .yaml or .yml extension.`)[1:],
 			return common.PreApplyEnvFilesAndTemplates(c, cliOpts)
 		},
 		Action: func(c *cli.Context) error {
-			if code := LintAction(c, cliOpts, os.Stderr); code != 0 {
-				os.Exit(code)
-			}
-			return nil
+			return LintAction(c, cliOpts, os.Stderr)
 		},
 	}
 }
@@ -191,11 +188,10 @@ func lintMDSnippets(path string, spec docs.FieldSpecs, lConf docs.LintConfig) (p
 
 // LintAction performs the benthos lint subcommand and returns the appropriate
 // exit code. This function is exported for testing purposes only.
-func LintAction(c *cli.Context, opts *common.CLIOpts, stderr io.Writer) int {
+func LintAction(c *cli.Context, opts *common.CLIOpts, stderr io.Writer) error {
 	targets, err := ifilepath.GlobsAndSuperPaths(ifs.OS(), c.Args().Slice(), "yaml", "yml")
 	if err != nil {
-		fmt.Fprintf(stderr, "Lint paths error: %v\n", err)
-		return 1
+		return fmt.Errorf("lint paths error: %w", err)
 	}
 	if conf := opts.RootFlags.GetConfig(c); conf != "" {
 		targets = append(targets, conf)
@@ -242,7 +238,7 @@ func LintAction(c *cli.Context, opts *common.CLIOpts, stderr io.Writer) int {
 	wg.Wait()
 
 	if len(pathLints) == 0 {
-		return 0
+		return nil
 	}
 
 	for _, lint := range pathLints {
@@ -253,5 +249,5 @@ func LintAction(c *cli.Context, opts *common.CLIOpts, stderr io.Writer) int {
 			fmt.Fprint(stderr, yellow(lintText))
 		}
 	}
-	return 1
+	return &common.ErrExitCode{Err: errors.New("lint errors"), Code: 1}
 }

--- a/internal/cli/list.go
+++ b/internal/cli/list.go
@@ -3,7 +3,6 @@ package cli
 import (
 	"encoding/json"
 	"fmt"
-	"os"
 	"strings"
 
 	"github.com/urfave/cli/v2"
@@ -52,7 +51,6 @@ components will be shown.
 		},
 		Action: func(c *cli.Context) error {
 			listComponents(c, opts)
-			os.Exit(0)
 			return nil
 		},
 	}

--- a/internal/cli/list.go
+++ b/internal/cli/list.go
@@ -89,13 +89,13 @@ func listComponents(c *cli.Context, opts *common.CLIOpts) {
 				continue
 			}
 			if i > 0 {
-				fmt.Println("")
+				fmt.Fprintln(opts.Stdout, "")
 			}
 			i++
 			title := cases.Title(language.English).String(strings.ReplaceAll(k, "-", " "))
-			fmt.Printf("%v:\n", title)
+			fmt.Fprintf(opts.Stdout, "%v:\n", title)
 			for _, t := range flat[k] {
-				fmt.Printf("  - %v\n", t)
+				fmt.Fprintf(opts.Stdout, "  - %v\n", t)
 			}
 		}
 	case "json":
@@ -111,25 +111,25 @@ func listComponents(c *cli.Context, opts *common.CLIOpts) {
 		if err != nil {
 			panic(err)
 		}
-		fmt.Println(string(jsonBytes))
+		fmt.Fprintln(opts.Stdout, string(jsonBytes))
 	case "json-full":
 		jsonBytes, err := json.Marshal(schema)
 		if err != nil {
 			panic(err)
 		}
-		fmt.Println(string(jsonBytes))
+		fmt.Fprintln(opts.Stdout, string(jsonBytes))
 	case "json-full-scrubbed":
 		schema.Scrub()
 		jsonBytes, err := json.Marshal(schema)
 		if err != nil {
 			panic(err)
 		}
-		fmt.Println(string(jsonBytes))
+		fmt.Fprintln(opts.Stdout, string(jsonBytes))
 	case "cue":
 		source, err := cuegen.GenerateSchema(schema)
 		if err != nil {
 			panic(err)
 		}
-		fmt.Println(string(source))
+		fmt.Fprintln(opts.Stdout, string(source))
 	}
 }

--- a/internal/cli/run.go
+++ b/internal/cli/run.go
@@ -1,8 +1,7 @@
 package cli
 
 import (
-	"fmt"
-	"os"
+	"errors"
 
 	"github.com/urfave/cli/v2"
 
@@ -27,13 +26,11 @@ Run a {{.ProductName}} config.
 		Action: func(c *cli.Context) error {
 			if c.Args().Len() > 0 {
 				if c.Args().Len() > 1 || opts.RootFlags.Config != "" {
-					fmt.Fprintln(os.Stderr, "A maximum of one config must be specified with the run command")
-					os.Exit(1)
+					return errors.New("a maximum of one config must be specified with the run command")
 				}
 				opts.RootFlags.Config = c.Args().First()
 			}
-			os.Exit(common.RunService(c, opts, false))
-			return nil
+			return common.RunService(c, opts, false)
 		},
 	}
 }

--- a/internal/cli/streams.go
+++ b/internal/cli/streams.go
@@ -1,8 +1,6 @@
 package cli
 
 import (
-	"os"
-
 	"github.com/urfave/cli/v2"
 
 	"github.com/redpanda-data/benthos/v4/internal/cli/common"
@@ -23,8 +21,8 @@ func streamsCliCommand(opts *common.CLIOpts) *cli.Command {
 
 		// Observability config only
 		&cli.StringFlag{
-			Name:    common.RootFlagConfig,
-			Aliases: []string{"c"},
+			Name:    "observability",
+			Aliases: []string{"o"},
 			Value:   "",
 			Usage:   "a path to a configuration file containing general service-wide fields such as http, logger, and so on",
 		},
@@ -57,8 +55,10 @@ For more information check out the docs at:
 			return common.PreApplyEnvFilesAndTemplates(c, opts)
 		},
 		Action: func(c *cli.Context) error {
-			os.Exit(common.RunService(c, opts, true))
-			return nil
+			if oConf := c.String("observability"); oConf != "" {
+				opts.RootFlags.Config = oConf
+			}
+			return common.RunService(c, opts, true)
 		},
 	}
 }

--- a/internal/cli/studio/pull.go
+++ b/internal/cli/studio/pull.go
@@ -66,12 +66,12 @@ files and execute them, replacing the previous stream running.`[1:],
 			token, secret := c.String("token"), c.String("token-secret")
 			if token == "" {
 				if token = os.Getenv("BSTDIO_NODE_TOKEN"); token == "" {
-					fmt.Fprintln(os.Stderr, "Must specify either --token or BSTDIO_NODE_TOKEN")
+					fmt.Fprintln(cliOpts.Stderr, "Must specify either --token or BSTDIO_NODE_TOKEN")
 				}
 			}
 			if secret == "" {
 				if secret = os.Getenv("BSTDIO_NODE_SECRET"); secret == "" {
-					fmt.Fprintln(os.Stderr, "Must specify either --token-secret or BSTDIO_NODE_SECRET")
+					fmt.Fprintln(cliOpts.Stderr, "Must specify either --token-secret or BSTDIO_NODE_SECRET")
 				}
 			}
 			if token == "" || secret == "" {

--- a/internal/cli/studio/pull.go
+++ b/internal/cli/studio/pull.go
@@ -2,6 +2,7 @@ package studio
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 	"os/signal"
@@ -59,8 +60,7 @@ files and execute them, replacing the previous stream running.`[1:],
 		Action: func(c *cli.Context) error {
 			// Start off by warning about all unsupported flags
 			if cliOpts.RootFlags.GetWatcher(c) {
-				fmt.Fprintln(os.Stderr, "The --watcher/-w flag is not supported in this mode of operation")
-				os.Exit(1)
+				return errors.New("the --watcher/-w flag is not supported in this mode of operation")
 			}
 
 			token, secret := c.String("token"), c.String("token-secret")
@@ -75,13 +75,12 @@ files and execute them, replacing the previous stream running.`[1:],
 				}
 			}
 			if token == "" || secret == "" {
-				os.Exit(1)
+				return errors.New("must specify a node token and secret")
 			}
 
 			pullRunner, err := NewPullRunner(c, cliOpts, token, secret)
 			if err != nil {
-				fmt.Fprintf(os.Stderr, "Error encountered whilst initiating studio sync: %v\n", err)
-				os.Exit(1)
+				return fmt.Errorf("error encountered whilst initiating studio sync: %v", err)
 			}
 
 			sigCtx, done := context.WithCancel(context.Background())
@@ -124,10 +123,7 @@ files and execute them, replacing the previous stream running.`[1:],
 					sigNameMut.Lock()
 					pullRunner.logger.Info("Received signal %s, shutting down", sigName)
 					sigNameMut.Unlock()
-					if pullRunner.Stop(context.Background()) != nil {
-						os.Exit(1)
-					}
-					return nil
+					return pullRunner.Stop(context.Background())
 				}
 			}
 		},

--- a/internal/cli/studio/pull_runner.go
+++ b/internal/cli/studio/pull_runner.go
@@ -5,7 +5,6 @@ import (
 	"errors"
 	"fmt"
 	"net/url"
-	"os"
 	"path"
 	"runtime/pprof"
 	"time"
@@ -473,7 +472,7 @@ func (r *PullRunner) Stop(ctx context.Context) error {
 				"Service failed to close the running stream cleanly within allocated time: %v."+
 					" Exiting forcefully and dumping stack trace to stderr\n", err,
 			)
-			_ = pprof.Lookup("goroutine").WriteTo(os.Stderr, 1)
+			_ = pprof.Lookup("goroutine").WriteTo(r.cliOpts.Stderr, 1)
 			return err
 		}
 		if r.stoppableMgr == nil {
@@ -484,7 +483,7 @@ func (r *PullRunner) Stop(ctx context.Context) error {
 				"Service failed to close resources cleanly within allocated time: %v."+
 					" Exiting forcefully and dumping stack trace to stderr\n", err,
 			)
-			_ = pprof.Lookup("goroutine").WriteTo(os.Stderr, 1)
+			_ = pprof.Lookup("goroutine").WriteTo(r.cliOpts.Stderr, 1)
 			return err
 		}
 		return nil

--- a/internal/cli/studio/sync_schema.go
+++ b/internal/cli/studio/sync_schema.go
@@ -7,7 +7,6 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"os"
 	"path"
 
 	"github.com/urfave/cli/v2"
@@ -49,8 +48,7 @@ page within the studio application.`[1:],
 
 			u, err := url.Parse(endpoint)
 			if err != nil {
-				fmt.Fprintf(os.Stderr, "Failed to parse endpoint: %v\n", err)
-				os.Exit(1)
+				return fmt.Errorf("failed to parse endpoint: %w", err)
 			}
 			u.Path = path.Join(u.Path, fmt.Sprintf("/api/v1/token/%v/session/%v/schema", tokenID, sessionID))
 
@@ -59,22 +57,19 @@ page within the studio application.`[1:],
 			schema.Scrub()
 			schemaBytes, err := json.Marshal(schema)
 			if err != nil {
-				fmt.Fprintf(os.Stderr, "Failed to encode schema: %v\n", err)
-				os.Exit(1)
+				return fmt.Errorf("failed to encode schema: %w", err)
 			}
 
 			res, err := http.Post(u.String(), "application/json", bytes.NewReader(schemaBytes))
 			if err != nil {
-				fmt.Fprintf(os.Stderr, "Sync request failed: %v\n", err)
-				os.Exit(1)
+				return fmt.Errorf("sync request failed: %w", err)
 			}
 
 			defer res.Body.Close()
 
 			if res.StatusCode < 200 || res.StatusCode > 299 {
 				resBytes, _ := io.ReadAll(res.Body)
-				fmt.Fprintf(os.Stderr, "Sync request failed (%v): %v\n", res.StatusCode, string(resBytes))
-				os.Exit(1)
+				return fmt.Errorf("sync request failed (%v): %v", res.StatusCode, string(resBytes))
 			}
 			return nil
 		},

--- a/internal/cli/template/lint.go
+++ b/internal/cli/template/lint.go
@@ -3,7 +3,6 @@ package template
 import (
 	"errors"
 	"fmt"
-	"os"
 
 	"github.com/fatih/color"
 	"github.com/urfave/cli/v2"
@@ -54,9 +53,9 @@ files with the .yaml or .yml extension.`)[1:],
 			for _, lint := range pathLints {
 				lintText := fmt.Sprintf("%v%v\n", lint.source, lint.lint.Error())
 				if lint.lint.Type == docs.LintFailedRead {
-					fmt.Fprint(os.Stderr, red(lintText))
+					fmt.Fprint(opts.Stderr, red(lintText))
 				} else {
-					fmt.Fprint(os.Stderr, yellow(lintText))
+					fmt.Fprint(opts.Stderr, yellow(lintText))
 				}
 			}
 			return &common.ErrExitCode{Err: errors.New("lint errors"), Code: 1}

--- a/internal/cli/template/lint.go
+++ b/internal/cli/template/lint.go
@@ -36,8 +36,7 @@ files with the .yaml or .yml extension.`)[1:],
 		Action: func(c *cli.Context) error {
 			targets, err := ifilepath.GlobsAndSuperPaths(ifs.OS(), c.Args().Slice(), "yaml", "yml")
 			if err != nil {
-				fmt.Fprintf(os.Stderr, "Lint paths error: %v\n", err)
-				os.Exit(1)
+				return fmt.Errorf("lint paths error: %w", err)
 			}
 			var pathLints []pathLint
 			for _, target := range targets {
@@ -50,7 +49,7 @@ files with the .yaml or .yml extension.`)[1:],
 				}
 			}
 			if len(pathLints) == 0 {
-				os.Exit(0)
+				return nil
 			}
 			for _, lint := range pathLints {
 				lintText := fmt.Sprintf("%v%v\n", lint.source, lint.lint.Error())
@@ -60,8 +59,7 @@ files with the .yaml or .yml extension.`)[1:],
 					fmt.Fprint(os.Stderr, yellow(lintText))
 				}
 			}
-			os.Exit(1)
-			return nil
+			return &common.ErrExitCode{Err: errors.New("lint errors"), Code: 1}
 		},
 	}
 }

--- a/internal/cli/test/cli.go
+++ b/internal/cli/test/cli.go
@@ -3,7 +3,6 @@ package test
 import (
 	"errors"
 	"fmt"
-	"os"
 
 	"github.com/urfave/cli/v2"
 
@@ -59,7 +58,7 @@ For more information check out the docs at:
 			if logLevel := c.String("log"); logLevel != "" {
 				logConf := log.NewConfig()
 				logConf.LogLevel = logLevel
-				logger, err := log.New(os.Stdout, ifs.OS(), logConf)
+				logger, err := log.New(cliOpts.Stdout, ifs.OS(), logConf)
 				if err != nil {
 					return fmt.Errorf("failed to init logger: %w", err)
 				}

--- a/public/service/service.go
+++ b/public/service/service.go
@@ -2,6 +2,8 @@ package service
 
 import (
 	"context"
+	"errors"
+	"fmt"
 	"log/slog"
 	"os"
 
@@ -43,7 +45,15 @@ func RunCLI(ctx context.Context, optFuncs ...CLIOptFunc) {
 		}
 		return l, nil
 	}
-	_ = cli.App(cliOpts.opts).RunContext(ctx, os.Args)
+
+	if err := cli.App(cliOpts.opts).RunContext(ctx, os.Args); err != nil {
+		var cerr *common.ErrExitCode
+		if errors.As(err, &cerr) {
+			os.Exit(cerr.Code)
+		}
+		fmt.Fprintln(os.Stderr, err.Error())
+		os.Exit(1)
+	}
 }
 
 // CLIOptBuilder represents a CLI opts builder.

--- a/public/service/servicetest/service.go
+++ b/public/service/servicetest/service.go
@@ -4,6 +4,9 @@ package servicetest
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"os"
 
 	"github.com/redpanda-data/benthos/v4/internal/cli"
 	"github.com/redpanda-data/benthos/v4/internal/cli/common"
@@ -19,5 +22,12 @@ import (
 // 3. The provided context has a deadline that is reached, triggering graceful termination
 // 4. The provided context is cancelled (WARNING, this prevents graceful termination)
 func RunCLIWithArgs(ctx context.Context, args ...string) {
-	_ = cli.App(common.NewCLIOpts(cli.Version, cli.DateBuilt)).RunContext(ctx, args)
+	if err := cli.App(common.NewCLIOpts(cli.Version, cli.DateBuilt)).RunContext(ctx, args); err != nil {
+		var cerr *common.ErrExitCode
+		if errors.As(err, &cerr) {
+			os.Exit(cerr.Code)
+		}
+		fmt.Fprintln(os.Stderr, err.Error())
+		os.Exit(1)
+	}
 }


### PR DESCRIPTION
This PR does a bit of refactoring so that all CLI subcommands are easier to test. The first part is getting it rid of (almost all) calls to `os.Exit`, those are replaced directly with returned errors. The second is using customisable handles for stdout and stderr writing, as this allows us to properly test the output of various commands without ugly command injection.

I've also renamed the new `-c` flag for streams mode to `-o/--observability` to hopefully make it clearer what the intention of that config file is.