### PR TITLE
Add Connection Status Access to RunCLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
 - Metadata fields `retry_count` and `backoff_duration` added to the `retry` processor. (@mihaitodor)
 - Parameter `escape_html` added to the `format_json()` Bloblang method. (@mihaitodor)
 - Go API: New generic key/value store methods added to the `*Resources` type. (@Jeffail)
+- Go API: Variadic options added to the public `service.RunCLI` function for customising cli args and accessing running stream data. (@Jeffail)
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ Changelog
 
 All notable changes to this project will be documented in this file.
 
-## 4.31.0 - TBD
+## 4.31.0 - 2024-07-10
 
 ### Added
 
@@ -12,6 +12,10 @@ All notable changes to this project will be documented in this file.
 - Parameter `escape_html` added to the `format_json()` Bloblang method. (@mihaitodor)
 - Go API: New generic key/value store methods added to the `*Resources` type. (@Jeffail)
 - Go API: Variadic options added to the public `service.RunCLI` function for customising cli args and accessing running stream data. (@Jeffail)
+- Go API: New `BloblangExecutor` and `InterpolationExecutor` added to the `MessageBatch`. (@Jeffail)
+- New `array` bloblang method. (@gramian)
+- Go API: New `CLIOptSetEnvVarLookup` cli option for customising config interpolations. (@Jeffail)
+- Algorithm `fnv32` added to the `hash` bloblang method. (@CallMeMhz)
 
 ### Changed
 

--- a/internal/bundle/tracing/input.go
+++ b/internal/bundle/tracing/input.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/Jeffail/shutdown"
 
+	"github.com/redpanda-data/benthos/v4/internal/component"
 	"github.com/redpanda-data/benthos/v4/internal/component/input"
 	"github.com/redpanda-data/benthos/v4/internal/message"
 )
@@ -68,8 +69,8 @@ func (t *tracedInput) TransactionChan() <-chan message.Transaction {
 	return t.tChan
 }
 
-func (t *tracedInput) Connected() bool {
-	return t.wrapped.Connected()
+func (t *tracedInput) ConnectionStatus() component.ConnectionStatuses {
+	return t.wrapped.ConnectionStatus()
 }
 
 func (t *tracedInput) TriggerStopConsuming() {

--- a/internal/bundle/tracing/output.go
+++ b/internal/bundle/tracing/output.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/Jeffail/shutdown"
 
+	"github.com/redpanda-data/benthos/v4/internal/component"
 	"github.com/redpanda-data/benthos/v4/internal/component/output"
 	"github.com/redpanda-data/benthos/v4/internal/message"
 )
@@ -67,8 +68,8 @@ func (t *tracedOutput) Consume(inChan <-chan message.Transaction) error {
 	return t.wrapped.Consume(t.tChan)
 }
 
-func (t *tracedOutput) Connected() bool {
-	return t.wrapped.Connected()
+func (t *tracedOutput) ConnectionStatus() component.ConnectionStatuses {
+	return t.wrapped.ConnectionStatus()
 }
 
 func (t *tracedOutput) TriggerCloseNow() {

--- a/internal/cli/common/manager.go
+++ b/internal/cli/common/manager.go
@@ -126,7 +126,7 @@ func RunManagerUntilStopped(
 	opts *CLIOpts,
 	conf config.Type,
 	stopMgr *StoppableManager,
-	stopStrm Stoppable,
+	stopStrm RunningStream,
 	dataStreamClosedChan chan struct{},
 ) error {
 	var exitDelay time.Duration

--- a/internal/cli/common/opts.go
+++ b/internal/cli/common/opts.go
@@ -15,6 +15,10 @@ import (
 	"github.com/redpanda-data/benthos/v4/internal/log"
 )
 
+// StreamInitFunc is an optional func to be called when a stream (or streams
+// mode) is initialised.
+type StreamInitFunc func(s RunningStream) error
+
 // CLIOpts contains the available CLI configuration options.
 type CLIOpts struct {
 	RootFlags *RootCommonFlags
@@ -38,6 +42,8 @@ type CLIOpts struct {
 	MainConfigSpecCtor   func() docs.FieldSpecs // TODO: This becomes a service.Environment
 	OnManagerInitialised func(mgr bundle.NewManagement, pConf *docs.ParsedConfig) error
 	OnLoggerInit         func(l log.Modular) (log.Modular, error)
+
+	OnStreamInit StreamInitFunc
 }
 
 // NewCLIOpts returns a new CLIOpts instance populated with default values.
@@ -72,6 +78,7 @@ func NewCLIOpts(version, dateBuilt string) *CLIOpts {
 		OnLoggerInit: func(l log.Modular) (log.Modular, error) {
 			return l, nil
 		},
+		OnStreamInit: func(s RunningStream) error { return nil },
 	}
 }
 

--- a/internal/cli/common/service.go
+++ b/internal/cli/common/service.go
@@ -98,6 +98,9 @@ func RunService(c *cli.Context, cliOpts *CLIOpts, streamsMode bool) error {
 		return err
 	}
 
+	if err := cliOpts.OnStreamInit(stoppableStream); err != nil {
+		return err
+	}
 	return RunManagerUntilStopped(c, cliOpts, conf, stoppableManager, stoppableStream, dataStreamClosedChan)
 }
 

--- a/internal/component/connection.go
+++ b/internal/component/connection.go
@@ -1,0 +1,66 @@
+package component
+
+// ConnectionStatus represents the current connection status of a given
+// component.
+type ConnectionStatus struct {
+	Label     string
+	Path      []string
+	Connected bool
+	Err       error
+}
+
+type ConnectionStatuses []*ConnectionStatus
+
+func (s ConnectionStatuses) AllActive() bool {
+	if len(s) == 0 {
+		return false
+	}
+	for _, c := range s {
+		if !c.Connected {
+			return false
+		}
+	}
+	return true
+}
+
+// ConnectionFailing returns a ConnectionStatus representing a component
+// connection where we are attempting to connect to the service but are
+// currently unable due to the provided error.
+func ConnectionFailing(o Observability, err error) *ConnectionStatus {
+	return &ConnectionStatus{
+		Label:     o.Label(),
+		Path:      o.Path(),
+		Connected: false,
+		Err:       err,
+	}
+}
+
+// ConnectionActive returns a ConnectionStatus representing a component
+// connection where we have an active connection.
+func ConnectionActive(o Observability) *ConnectionStatus {
+	return &ConnectionStatus{
+		Label:     o.Label(),
+		Path:      o.Path(),
+		Connected: true,
+	}
+}
+
+// ConnectionPending returns a ConnectionStatus representing a component that
+// has not yet attempted to establish its connection.
+func ConnectionPending(o Observability) *ConnectionStatus {
+	return &ConnectionStatus{
+		Label:     o.Label(),
+		Path:      o.Path(),
+		Connected: false,
+	}
+}
+
+// ConnectionClosed returns a ConnectionStatus representing a component that has
+// intentionally closed its connection.
+func ConnectionClosed(o Observability) *ConnectionStatus {
+	return &ConnectionStatus{
+		Label:     o.Label(),
+		Path:      o.Path(),
+		Connected: false,
+	}
+}

--- a/internal/component/connection.go
+++ b/internal/component/connection.go
@@ -9,8 +9,11 @@ type ConnectionStatus struct {
 	Err       error
 }
 
+// ConnectionStatuses represents an aggregate of connection statuses.
 type ConnectionStatuses []*ConnectionStatus
 
+// AllActive returns true if there is one or more connections and they are all
+// active.
 func (s ConnectionStatuses) AllActive() bool {
 	if len(s) == 0 {
 		return false

--- a/internal/component/errors.go
+++ b/internal/component/errors.go
@@ -32,6 +32,30 @@ func ErrInvalidType(typeStr, tried string) error {
 	}
 }
 
+//------------------------------------------------------------------------------
+
+// LabelledError is an error that could be returned by components annotated by
+// their label (or path) in order to provide extra context to which specific
+// component within a config is yielding it. This is particularly useful in
+// situations such as ConnectionStatus aggregates where a broker yields multiple
+// errors from a range of child components.
+type LabelledError struct {
+	Label string
+	Err   error
+}
+
+// Error returns a formatted error string.
+func (e *LabelledError) Error() string {
+	return fmt.Sprintf("%v: %v", e.Label, e.Err)
+}
+
+// Unwrap returns the underlying error value.
+func (e *LabelledError) Unwrap() error {
+	return e.Err
+}
+
+//------------------------------------------------------------------------------
+
 // Errors used throughout the codebase.
 var (
 	ErrTimeout    = errors.New("action timed out")

--- a/internal/component/input/async_reader.go
+++ b/internal/component/input/async_reader.go
@@ -242,8 +242,9 @@ func (r *AsyncReader) TransactionChan() <-chan message.Transaction {
 	return r.transactions
 }
 
-// Connected returns a boolean indicating whether this input is currently
-// connected to its target.
+// ConnectionStatus returns the current status of the given component
+// connection. The result is a slice in order to accommodate higher order
+// components that wrap several others.
 func (r *AsyncReader) ConnectionStatus() component.ConnectionStatuses {
 	return []*component.ConnectionStatus{
 		r.connection.Load(),

--- a/internal/component/input/batcher/batcher.go
+++ b/internal/component/input/batcher/batcher.go
@@ -152,7 +152,9 @@ func (m *Impl) loop() {
 	}
 }
 
-// Connected returns true if the underlying input is connected.
+// ConnectionStatus returns the current status of the given component
+// connection. The result is a slice in order to accommodate higher order
+// components that wrap several others.
 func (m *Impl) ConnectionStatus() component.ConnectionStatuses {
 	return m.child.ConnectionStatus()
 }

--- a/internal/component/input/batcher/batcher.go
+++ b/internal/component/input/batcher/batcher.go
@@ -8,6 +8,7 @@ import (
 	"github.com/Jeffail/shutdown"
 
 	"github.com/redpanda-data/benthos/v4/internal/batch/policy"
+	"github.com/redpanda-data/benthos/v4/internal/component"
 	"github.com/redpanda-data/benthos/v4/internal/component/input"
 	"github.com/redpanda-data/benthos/v4/internal/log"
 	"github.com/redpanda-data/benthos/v4/internal/message"
@@ -152,8 +153,8 @@ func (m *Impl) loop() {
 }
 
 // Connected returns true if the underlying input is connected.
-func (m *Impl) Connected() bool {
-	return m.child.Connected()
+func (m *Impl) ConnectionStatus() component.ConnectionStatuses {
+	return m.child.ConnectionStatus()
 }
 
 // TransactionChan returns the channel used for consuming messages from this

--- a/internal/component/input/interface.go
+++ b/internal/component/input/interface.go
@@ -3,6 +3,7 @@ package input
 import (
 	"context"
 
+	"github.com/redpanda-data/benthos/v4/internal/component"
 	"github.com/redpanda-data/benthos/v4/internal/message"
 )
 
@@ -14,9 +15,10 @@ type Streamed interface {
 	// transaction will be sent.
 	TransactionChan() <-chan message.Transaction
 
-	// Connected returns a boolean indicating whether this input is currently
-	// connected to its target.
-	Connected() bool
+	// ConnectionStatus returns the current status of the given component
+	// connection. The result is a slice in order to accommodate higher order
+	// components that wrap several others.
+	ConnectionStatus() component.ConnectionStatuses
 
 	// TriggerStopConsuming instructs the input to start shutting down resources
 	// once all pending messages are delivered and acknowledged. This call does

--- a/internal/component/input/wrap_with_pipeline.go
+++ b/internal/component/input/wrap_with_pipeline.go
@@ -3,6 +3,7 @@ package input
 import (
 	"context"
 
+	"github.com/redpanda-data/benthos/v4/internal/component"
 	iprocessor "github.com/redpanda-data/benthos/v4/internal/component/processor"
 	"github.com/redpanda-data/benthos/v4/internal/message"
 )
@@ -51,10 +52,10 @@ func (i *WithPipeline) TransactionChan() <-chan message.Transaction {
 	return i.pipe.TransactionChan()
 }
 
-// Connected returns a boolean indicating whether this input is currently
-// connected to its target.
-func (i *WithPipeline) Connected() bool {
-	return i.in.Connected()
+// ConnectionStatus returns the current status of the connection of the wrapped
+// component.
+func (i *WithPipeline) ConnectionStatus() component.ConnectionStatuses {
+	return i.in.ConnectionStatus()
 }
 
 //------------------------------------------------------------------------------

--- a/internal/component/input/wrap_with_pipeline_test.go
+++ b/internal/component/input/wrap_with_pipeline_test.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/redpanda-data/benthos/v4/internal/component"
 	"github.com/redpanda-data/benthos/v4/internal/component/input"
 	iprocessor "github.com/redpanda-data/benthos/v4/internal/component/processor"
 	"github.com/redpanda-data/benthos/v4/internal/message"
@@ -26,8 +27,10 @@ func (m *mockInput) TransactionChan() <-chan message.Transaction {
 	return m.ts
 }
 
-func (m *mockInput) Connected() bool {
-	return true
+func (m *mockInput) ConnectionStatus() component.ConnectionStatuses {
+	return component.ConnectionStatuses{
+		component.ConnectionActive(component.NoopObservability()),
+	}
 }
 
 func (m *mockInput) TriggerStopConsuming() {

--- a/internal/component/observability.go
+++ b/internal/component/observability.go
@@ -15,6 +15,8 @@ type Observability interface {
 	Metrics() metrics.Type
 	Logger() log.Modular
 	Tracer() trace.TracerProvider
+	Path() []string
+	Label() string
 }
 
 type mockObs struct{}
@@ -29,6 +31,14 @@ func (m mockObs) Logger() log.Modular {
 
 func (m mockObs) Tracer() trace.TracerProvider {
 	return noop.NewTracerProvider()
+}
+
+func (m mockObs) Path() []string {
+	return nil
+}
+
+func (m mockObs) Label() string {
+	return ""
 }
 
 // NoopObservability returns an implementation of Observability that does

--- a/internal/component/output/batcher/batcher.go
+++ b/internal/component/output/batcher/batcher.go
@@ -159,10 +159,11 @@ func (m *Impl) loop() {
 	}
 }
 
-// Connected returns a boolean indicating whether this output is currently
-// connected to its target.
-func (m *Impl) Connected() bool {
-	return m.child.Connected()
+// ConnectionStatus returns the current status of the given component
+// connection. The result is a slice in order to accommodate higher order
+// components that wrap several others.
+func (m *Impl) ConnectionStatus() component.ConnectionStatuses {
+	return m.child.ConnectionStatus()
 }
 
 // Consume assigns a messages channel for the output to read.

--- a/internal/component/output/interface.go
+++ b/internal/component/output/interface.go
@@ -3,6 +3,7 @@ package output
 import (
 	"context"
 
+	"github.com/redpanda-data/benthos/v4/internal/component"
 	"github.com/redpanda-data/benthos/v4/internal/message"
 )
 
@@ -12,9 +13,10 @@ type Sync interface {
 	// WriteTransaction attempts to write a transaction to an output.
 	WriteTransaction(context.Context, message.Transaction) error
 
-	// Connected returns a boolean indicating whether this output is currently
-	// connected to its target.
-	Connected() bool
+	// ConnectionStatus returns the current status of the given component
+	// connection. The result is a slice in order to accommodate higher order
+	// components that wrap several others.
+	ConnectionStatus() component.ConnectionStatuses
 
 	// TriggerStopConsuming instructs the output to start shutting down
 	// resources once all pending messages are delivered and acknowledged.
@@ -35,9 +37,10 @@ type Streamed interface {
 	// Consume starts the type receiving transactions from a Transactor.
 	Consume(<-chan message.Transaction) error
 
-	// Connected returns a boolean indicating whether this output is currently
-	// connected to its target.
-	Connected() bool
+	// ConnectionStatus returns the current status of the given component
+	// connection. The result is a slice in order to accommodate higher order
+	// components that wrap several others.
+	ConnectionStatus() component.ConnectionStatuses
 
 	// TriggerCloseNow triggers the shut down of this component but should not
 	// block the calling goroutine.

--- a/internal/component/output/not_batched.go
+++ b/internal/component/output/not_batched.go
@@ -148,8 +148,8 @@ func (n *notBatchedOutput) Consume(ts <-chan message.Transaction) error {
 	return nil
 }
 
-func (n *notBatchedOutput) Connected() bool {
-	return n.out.Connected()
+func (n *notBatchedOutput) ConnectionStatus() component.ConnectionStatuses {
+	return n.out.ConnectionStatus()
 }
 
 func (n *notBatchedOutput) TriggerCloseNow() {

--- a/internal/component/output/wrap_with_pipeline.go
+++ b/internal/component/output/wrap_with_pipeline.go
@@ -3,6 +3,7 @@ package output
 import (
 	"context"
 
+	"github.com/redpanda-data/benthos/v4/internal/component"
 	iprocessor "github.com/redpanda-data/benthos/v4/internal/component/processor"
 	"github.com/redpanda-data/benthos/v4/internal/message"
 )
@@ -51,10 +52,11 @@ func (i *WithPipeline) Consume(tsChan <-chan message.Transaction) error {
 	return i.pipe.Consume(tsChan)
 }
 
-// Connected returns a boolean indicating whether this output is currently
-// connected to its target.
-func (i *WithPipeline) Connected() bool {
-	return i.out.Connected()
+// ConnectionStatus returns the current status of the given component
+// connection. The result is a slice in order to accommodate higher order
+// components that wrap several others.
+func (i *WithPipeline) ConnectionStatus() component.ConnectionStatuses {
+	return i.out.ConnectionStatus()
 }
 
 //------------------------------------------------------------------------------

--- a/internal/component/output/wrap_with_pipeline_test.go
+++ b/internal/component/output/wrap_with_pipeline_test.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/stretchr/testify/require"
 
+	"github.com/redpanda-data/benthos/v4/internal/component"
 	"github.com/redpanda-data/benthos/v4/internal/component/output"
 	"github.com/redpanda-data/benthos/v4/internal/component/processor"
 	"github.com/redpanda-data/benthos/v4/internal/component/testutil"
@@ -29,8 +30,10 @@ func (m *mockOutput) Consume(ts <-chan message.Transaction) error {
 	return nil
 }
 
-func (m *mockOutput) Connected() bool {
-	return true
+func (m *mockOutput) ConnectionStatus() component.ConnectionStatuses {
+	return component.ConnectionStatuses{
+		component.ConnectionActive(component.NoopObservability()),
+	}
 }
 
 func (m *mockOutput) TriggerCloseNow() {

--- a/internal/impl/io/input_dynamic_fan_in.go
+++ b/internal/impl/io/input_dynamic_fan_in.go
@@ -97,9 +97,9 @@ func (d *dynamicFanInInput) TransactionChan() <-chan message.Transaction {
 	return d.transactionChan
 }
 
-func (d *dynamicFanInInput) Connected() bool {
-	// Always return true as this is fuzzy right now.
-	return true
+func (d *dynamicFanInInput) ConnectionStatus() component.ConnectionStatuses {
+	// Always return nil as this is fuzzy right now.
+	return nil
 }
 
 func (d *dynamicFanInInput) addInput(ident string, in input.Streamed) error {

--- a/internal/impl/io/input_dynamic_fan_in.go
+++ b/internal/impl/io/input_dynamic_fan_in.go
@@ -98,7 +98,8 @@ func (d *dynamicFanInInput) TransactionChan() <-chan message.Transaction {
 }
 
 func (d *dynamicFanInInput) ConnectionStatus() component.ConnectionStatuses {
-	// Always return nil as this is fuzzy right now.
+	// TODO: We need to refactor the mechanisms for serving new inputs in order
+	// to allow access from here.
 	return nil
 }
 

--- a/internal/impl/io/input_http_server.go
+++ b/internal/impl/io/input_http_server.go
@@ -25,6 +25,7 @@ import (
 
 	"github.com/redpanda-data/benthos/v4/internal/api"
 	"github.com/redpanda-data/benthos/v4/internal/bundle"
+	"github.com/redpanda-data/benthos/v4/internal/component"
 	"github.com/redpanda-data/benthos/v4/internal/component/input"
 	"github.com/redpanda-data/benthos/v4/internal/component/interop"
 	"github.com/redpanda-data/benthos/v4/internal/component/metrics"
@@ -907,10 +908,10 @@ func (h *httpServerInput) TransactionChan() <-chan message.Transaction {
 	return h.transactions
 }
 
-// Connected returns a boolean indicating whether this input is currently
-// connected to its target.
-func (h *httpServerInput) Connected() bool {
-	return true
+func (h *httpServerInput) ConnectionStatus() component.ConnectionStatuses {
+	return component.ConnectionStatuses{
+		component.ConnectionActive(h.mgr),
+	}
 }
 
 func (h *httpServerInput) TriggerStopConsuming() {

--- a/internal/impl/io/output_dynamic_fan_out.go
+++ b/internal/impl/io/output_dynamic_fan_out.go
@@ -282,15 +282,13 @@ func (d *dynamicFanOutOutputBroker) loop() {
 	}
 }
 
-func (d *dynamicFanOutOutputBroker) Connected() bool {
+func (d *dynamicFanOutOutputBroker) ConnectionStatus() (s component.ConnectionStatuses) {
 	d.outputsMut.RLock()
 	defer d.outputsMut.RUnlock()
 	for _, out := range d.outputs {
-		if !out.output.Connected() {
-			return false
-		}
+		s = append(s, out.output.ConnectionStatus()...)
 	}
-	return true
+	return
 }
 
 func (d *dynamicFanOutOutputBroker) TriggerCloseNow() {

--- a/internal/impl/io/output_http_server.go
+++ b/internal/impl/io/output_http_server.go
@@ -180,6 +180,7 @@ func init() {
 type httpServerOutput struct {
 	conf hsoConfig
 	log  log.Modular
+	mgr  bundle.NewManagement
 
 	mux    *mux.Router
 	server *http.Server
@@ -223,6 +224,7 @@ func newHTTPServerOutput(conf hsoConfig, mgr bundle.NewManagement) (output.Strea
 		shutSig: shutdown.NewSignaller(),
 		conf:    conf,
 		log:     mgr.Logger(),
+		mgr:     mgr,
 		mux:     gMux,
 		server:  server,
 
@@ -473,9 +475,10 @@ func (h *httpServerOutput) Consume(ts <-chan message.Transaction) error {
 	return nil
 }
 
-func (h *httpServerOutput) Connected() bool {
-	// Always return true as this is fuzzy right now.
-	return true
+func (h *httpServerOutput) ConnectionStatus() component.ConnectionStatuses {
+	return component.ConnectionStatuses{
+		component.ConnectionActive(h.mgr),
+	}
 }
 
 func (h *httpServerOutput) TriggerCloseNow() {

--- a/internal/impl/pure/input_broker_fan_in.go
+++ b/internal/impl/pure/input_broker_fan_in.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/Jeffail/shutdown"
 
+	"github.com/redpanda-data/benthos/v4/internal/component"
 	"github.com/redpanda-data/benthos/v4/internal/component/input"
 	"github.com/redpanda-data/benthos/v4/internal/message"
 )
@@ -77,20 +78,19 @@ func (i *fanInInputBroker) TransactionChan() <-chan message.Transaction {
 	return i.transactions
 }
 
-func (i *fanInInputBroker) Connected() bool {
+func (i *fanInInputBroker) ConnectionStatus() component.ConnectionStatuses {
 	i.remainingMapMut.Lock()
 	defer i.remainingMapMut.Unlock()
 
 	if len(i.remainingMap) == 0 {
-		return false
+		return nil
 	}
 
+	var statuses component.ConnectionStatuses
 	for index := range i.remainingMap {
-		if !i.closables[index].Connected() {
-			return false
-		}
+		statuses = append(statuses, i.closables[index].ConnectionStatus()...)
 	}
-	return true
+	return statuses
 }
 
 func (i *fanInInputBroker) loop() {

--- a/internal/impl/pure/input_broker_fan_in_test.go
+++ b/internal/impl/pure/input_broker_fan_in_test.go
@@ -90,15 +90,15 @@ func TestFanInConnected(t *testing.T) {
 	fanIn, err := newFanInInputBroker(Inputs)
 	require.NoError(t, err)
 
-	assert.True(t, fanIn.Connected())
+	assert.True(t, fanIn.ConnectionStatus().AllActive())
 
 	close(tInOne)
 	time.Sleep(time.Millisecond * 100)
-	assert.True(t, fanIn.Connected())
+	assert.True(t, fanIn.ConnectionStatus().AllActive())
 
 	close(tInTwo)
 	assert.Eventually(t, func() bool {
-		return !fanIn.Connected()
+		return !fanIn.ConnectionStatus().AllActive()
 	}, time.Second, time.Millisecond*10)
 }
 

--- a/internal/impl/pure/input_inproc.go
+++ b/internal/impl/pure/input_inproc.go
@@ -7,6 +7,7 @@ import (
 	"github.com/Jeffail/shutdown"
 
 	"github.com/redpanda-data/benthos/v4/internal/bundle"
+	"github.com/redpanda-data/benthos/v4/internal/component"
 	"github.com/redpanda-data/benthos/v4/internal/component/interop"
 	"github.com/redpanda-data/benthos/v4/internal/component/metrics"
 	"github.com/redpanda-data/benthos/v4/internal/log"
@@ -108,8 +109,10 @@ func (i *inprocInput) TransactionChan() <-chan message.Transaction {
 	return i.transactions
 }
 
-func (i *inprocInput) Connected() bool {
-	return true
+func (i *inprocInput) ConnectionStatus() component.ConnectionStatuses {
+	return component.ConnectionStatuses{
+		component.ConnectionActive(i.mgr),
+	}
 }
 
 func (i *inprocInput) TriggerStopConsuming() {

--- a/internal/impl/pure/input_read_until.go
+++ b/internal/impl/pure/input_read_until.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Jeffail/shutdown"
 
 	"github.com/redpanda-data/benthos/v4/internal/bloblang/mapping"
+	"github.com/redpanda-data/benthos/v4/internal/component"
 	"github.com/redpanda-data/benthos/v4/internal/component/input"
 	"github.com/redpanda-data/benthos/v4/internal/component/interop"
 	"github.com/redpanda-data/benthos/v4/internal/log"
@@ -302,15 +303,13 @@ func (r *readUntilInput) TransactionChan() <-chan message.Transaction {
 	return r.transactions
 }
 
-// Connected returns a boolean indicating whether this input is currently
-// connected to its target.
-func (r *readUntilInput) Connected() bool {
+func (r *readUntilInput) ConnectionStatus() component.ConnectionStatuses {
 	wrappedP := r.wrappedInputLocked.Load()
 	if wrappedP != nil {
 		i := *wrappedP
-		return i.Connected()
+		return i.ConnectionStatus()
 	}
-	return false
+	return nil
 }
 
 func (r *readUntilInput) TriggerStopConsuming() {

--- a/internal/impl/pure/input_resource.go
+++ b/internal/impl/pure/input_resource.go
@@ -144,11 +144,13 @@ func (r *resourceInput) TransactionChan() (tChan <-chan message.Transaction) {
 	return r.tChan
 }
 
-func (r *resourceInput) Connected() (isConnected bool) {
+func (r *resourceInput) ConnectionStatus() (s component.ConnectionStatuses) {
 	if err := r.mgr.AccessInput(context.Background(), r.name, func(i input.Streamed) {
-		isConnected = i.Connected()
+		s = i.ConnectionStatus()
 	}); err != nil {
-		r.log.Error("Failed to obtain input resource '%v': %v", r.name, err)
+		return component.ConnectionStatuses{
+			component.ConnectionFailing(r.mgr, err),
+		}
 	}
 	return
 }

--- a/internal/impl/pure/input_sequence.go
+++ b/internal/impl/pure/input_sequence.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/Jeffail/shutdown"
 
+	"github.com/redpanda-data/benthos/v4/internal/component"
 	"github.com/redpanda-data/benthos/v4/internal/component/input"
 	"github.com/redpanda-data/benthos/v4/internal/component/interop"
 	"github.com/redpanda-data/benthos/v4/internal/message"
@@ -602,11 +603,11 @@ func (r *sequenceInput) TransactionChan() <-chan message.Transaction {
 	return r.transactions
 }
 
-func (r *sequenceInput) Connected() bool {
+func (r *sequenceInput) ConnectionStatus() component.ConnectionStatuses {
 	if t, _ := r.getTarget(); t != nil {
-		return t.Connected()
+		return t.ConnectionStatus()
 	}
-	return false
+	return nil
 }
 
 func (r *sequenceInput) TriggerStopConsuming() {

--- a/internal/impl/pure/output_broker_fan_out.go
+++ b/internal/impl/pure/output_broker_fan_out.go
@@ -48,13 +48,11 @@ func (o *fanOutOutputBroker) Consume(transactions <-chan message.Transaction) er
 	return nil
 }
 
-func (o *fanOutOutputBroker) Connected() bool {
+func (o *fanOutOutputBroker) ConnectionStatus() (s component.ConnectionStatuses) {
 	for _, out := range o.outputs {
-		if !out.Connected() {
-			return false
-		}
+		s = append(s, out.ConnectionStatus()...)
 	}
-	return true
+	return
 }
 
 func (o *fanOutOutputBroker) loop() {

--- a/internal/impl/pure/output_broker_fan_out_sequential.go
+++ b/internal/impl/pure/output_broker_fan_out_sequential.go
@@ -49,13 +49,11 @@ func (o *fanOutSequentialOutputBroker) Consume(transactions <-chan message.Trans
 	return nil
 }
 
-func (o *fanOutSequentialOutputBroker) Connected() bool {
+func (o *fanOutSequentialOutputBroker) ConnectionStatus() (s component.ConnectionStatuses) {
 	for _, out := range o.outputs {
-		if !out.Connected() {
-			return false
-		}
+		s = append(s, out.ConnectionStatus()...)
 	}
-	return true
+	return
 }
 
 func (o *fanOutSequentialOutputBroker) loop() {

--- a/internal/impl/pure/output_broker_fan_out_sequential_test.go
+++ b/internal/impl/pure/output_broker_fan_out_sequential_test.go
@@ -33,7 +33,7 @@ func TestBasicFanOutSequential(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, oTM.Consume(readChan))
 
-	assert.True(t, oTM.Connected())
+	assert.True(t, oTM.ConnectionStatus().AllActive())
 
 	tCtx, done := context.WithTimeout(context.Background(), time.Second*5)
 	defer done()

--- a/internal/impl/pure/output_broker_fan_out_test.go
+++ b/internal/impl/pure/output_broker_fan_out_test.go
@@ -37,7 +37,7 @@ func TestBasicFanOut(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, oTM.Consume(readChan))
 
-	assert.True(t, oTM.Connected())
+	assert.True(t, oTM.ConnectionStatus().AllActive())
 
 	tCtx, done := context.WithTimeout(context.Background(), time.Second*10)
 	defer done()
@@ -95,7 +95,7 @@ func TestBasicFanOutMutations(t *testing.T) {
 	require.NoError(t, err)
 	require.NoError(t, oTM.Consume(readChan))
 
-	assert.True(t, oTM.Connected())
+	assert.True(t, oTM.ConnectionStatus().AllActive())
 
 	tCtx, done := context.WithTimeout(context.Background(), time.Second*10)
 	defer done()

--- a/internal/impl/pure/output_broker_greedy.go
+++ b/internal/impl/pure/output_broker_greedy.go
@@ -3,6 +3,7 @@ package pure
 import (
 	"context"
 
+	"github.com/redpanda-data/benthos/v4/internal/component"
 	"github.com/redpanda-data/benthos/v4/internal/component/output"
 	"github.com/redpanda-data/benthos/v4/internal/message"
 )
@@ -26,13 +27,11 @@ func (g *greedyOutputBroker) Consume(ts <-chan message.Transaction) error {
 	return nil
 }
 
-func (g *greedyOutputBroker) Connected() bool {
+func (g *greedyOutputBroker) ConnectionStatus() (s component.ConnectionStatuses) {
 	for _, out := range g.outputs {
-		if !out.Connected() {
-			return false
-		}
+		s = append(s, out.ConnectionStatus()...)
 	}
-	return true
+	return
 }
 
 func (g *greedyOutputBroker) TriggerCloseNow() {

--- a/internal/impl/pure/output_broker_round_robin.go
+++ b/internal/impl/pure/output_broker_round_robin.go
@@ -45,13 +45,11 @@ func (o *roundRobinOutputBroker) Consume(ts <-chan message.Transaction) error {
 	return nil
 }
 
-func (o *roundRobinOutputBroker) Connected() bool {
+func (o *roundRobinOutputBroker) ConnectionStatus() (s component.ConnectionStatuses) {
 	for _, out := range o.outputs {
-		if !out.Connected() {
-			return false
-		}
+		s = append(s, out.ConnectionStatus()...)
 	}
-	return true
+	return
 }
 
 func (o *roundRobinOutputBroker) loop() {

--- a/internal/impl/pure/output_drop_on.go
+++ b/internal/impl/pure/output_drop_on.go
@@ -285,8 +285,8 @@ func (d *dropOnWriter) Consume(ts <-chan message.Transaction) error {
 	return nil
 }
 
-func (d *dropOnWriter) Connected() bool {
-	return d.wrapped.Connected()
+func (d *dropOnWriter) ConnectionStatus() component.ConnectionStatuses {
+	return d.wrapped.ConnectionStatus()
 }
 
 func (d *dropOnWriter) TriggerCloseNow() {

--- a/internal/impl/pure/output_fallback.go
+++ b/internal/impl/pure/output_fallback.go
@@ -146,15 +146,11 @@ func (t *fallbackBroker) Consume(ts <-chan message.Transaction) error {
 	return nil
 }
 
-// Connected returns a boolean indicating whether this output is currently
-// connected to its target.
-func (t *fallbackBroker) Connected() bool {
+func (t *fallbackBroker) ConnectionStatus() (s component.ConnectionStatuses) {
 	for _, out := range t.outputs {
-		if !out.Connected() {
-			return false
-		}
+		s = append(s, out.ConnectionStatus()...)
 	}
-	return true
+	return
 }
 
 //------------------------------------------------------------------------------

--- a/internal/impl/pure/output_inproc.go
+++ b/internal/impl/pure/output_inproc.go
@@ -105,8 +105,10 @@ func (i *inprocOutput) Consume(ts <-chan message.Transaction) error {
 	return nil
 }
 
-func (i *inprocOutput) Connected() bool {
-	return true
+func (i *inprocOutput) ConnectionStatus() component.ConnectionStatuses {
+	return component.ConnectionStatuses{
+		component.ConnectionActive(i.mgr),
+	}
 }
 
 func (i *inprocOutput) TriggerCloseNow() {

--- a/internal/impl/pure/output_reject_errored.go
+++ b/internal/impl/pure/output_reject_errored.go
@@ -136,10 +136,8 @@ func (t *rejectErroredBroker) Consume(ts <-chan message.Transaction) error {
 	return nil
 }
 
-// Connected returns a boolean indicating whether this output is currently
-// connected to its target.
-func (t *rejectErroredBroker) Connected() bool {
-	return t.output.Connected()
+func (t *rejectErroredBroker) ConnectionStatus() component.ConnectionStatuses {
+	return t.output.ConnectionStatus()
 }
 
 //------------------------------------------------------------------------------

--- a/internal/impl/pure/output_resource.go
+++ b/internal/impl/pure/output_resource.go
@@ -145,12 +145,13 @@ func (r *resourceOutput) Consume(ts <-chan message.Transaction) error {
 	return nil
 }
 
-func (r *resourceOutput) Connected() (isConnected bool) {
-	var err error
-	if err = r.mgr.AccessOutput(context.Background(), r.name, func(o output.Sync) {
-		isConnected = o.Connected()
+func (r *resourceOutput) ConnectionStatus() (s component.ConnectionStatuses) {
+	if err := r.mgr.AccessOutput(context.Background(), r.name, func(o output.Sync) {
+		s = o.ConnectionStatus()
 	}); err != nil {
-		r.log.Error("Failed to obtain output resource '%v': %v", r.name, err)
+		return component.ConnectionStatuses{
+			component.ConnectionFailing(r.mgr, err),
+		}
 	}
 	return
 }

--- a/internal/impl/pure/output_resource_test.go
+++ b/internal/impl/pure/output_resource_test.go
@@ -37,7 +37,7 @@ func TestResourceOutput(t *testing.T) {
 	p, err := mgr.NewOutput(nConf)
 	require.NoError(t, err)
 
-	assert.True(t, p.Connected())
+	assert.True(t, p.ConnectionStatus().AllActive())
 
 	tChan := make(chan message.Transaction)
 	assert.NoError(t, p.Consume(tChan))

--- a/internal/impl/pure/output_retry.go
+++ b/internal/impl/pure/output_retry.go
@@ -248,10 +248,8 @@ func (r *indefiniteRetry) Consume(ts <-chan message.Transaction) error {
 	return nil
 }
 
-// Connected returns a boolean indicating whether this output is currently
-// connected to its target.
-func (r *indefiniteRetry) Connected() bool {
-	return r.wrapped.Connected()
+func (r *indefiniteRetry) ConnectionStatus() component.ConnectionStatuses {
+	return r.wrapped.ConnectionStatus()
 }
 
 // CloseAsync shuts down the Retry input and stops processing requests.

--- a/internal/impl/pure/output_switch.go
+++ b/internal/impl/pure/output_switch.go
@@ -271,13 +271,11 @@ func (o *switchOutput) Consume(transactions <-chan message.Transaction) error {
 	return nil
 }
 
-func (o *switchOutput) Connected() bool {
+func (o *switchOutput) ConnectionStatus() (s component.ConnectionStatuses) {
 	for _, out := range o.outputs {
-		if !out.Connected() {
-			return false
-		}
+		s = append(s, out.ConnectionStatus()...)
 	}
-	return true
+	return
 }
 
 func (o *switchOutput) dispatchToTargets(

--- a/internal/impl/pure/processor_workflow_test.go
+++ b/internal/impl/pure/processor_workflow_test.go
@@ -1032,7 +1032,7 @@ workflow:
 	defer done()
 
 	go func() {
-		assert.NoError(t, strm.Run(tCtx))
+		_ = strm.Run(tCtx)
 	}()
 	require.NoError(t, inFunc(tCtx, service.NewMessage([]byte(`{"id":"hello world","content":"waddup"}`))))
 	require.NoError(t, strm.Stop(tCtx))

--- a/internal/manager/input_wrapper.go
+++ b/internal/manager/input_wrapper.go
@@ -81,8 +81,9 @@ func (w *InputWrapper) TransactionChan() <-chan message.Transaction {
 	return w.tranChan
 }
 
-// Connected returns a boolean indicating whether the wrapped input is currently
-// connected to its target.
+// ConnectionStatus returns the current status of the given component
+// connection. The result is a slice in order to accommodate higher order
+// components that wrap several others.
 func (w *InputWrapper) ConnectionStatus() (s component.ConnectionStatuses) {
 	w.inputLock.Lock()
 	if w.ctrl.input != nil {

--- a/internal/manager/input_wrapper.go
+++ b/internal/manager/input_wrapper.go
@@ -83,11 +83,13 @@ func (w *InputWrapper) TransactionChan() <-chan message.Transaction {
 
 // Connected returns a boolean indicating whether the wrapped input is currently
 // connected to its target.
-func (w *InputWrapper) Connected() bool {
+func (w *InputWrapper) ConnectionStatus() (s component.ConnectionStatuses) {
 	w.inputLock.Lock()
-	con := w.ctrl.input != nil && w.ctrl.input.Connected()
+	if w.ctrl.input != nil {
+		s = w.ctrl.input.ConnectionStatus()
+	}
 	w.inputLock.Unlock()
-	return con
+	return
 }
 
 func (w *InputWrapper) loop() {

--- a/internal/manager/mock/input.go
+++ b/internal/manager/mock/input.go
@@ -4,12 +4,14 @@ import (
 	"context"
 	"sync"
 
+	"github.com/redpanda-data/benthos/v4/internal/component"
 	"github.com/redpanda-data/benthos/v4/internal/message"
 )
 
 // Input provides a mocked input implementation.
 type Input struct {
 	TChan     chan message.Transaction
+	closed    bool
 	closeOnce sync.Once
 }
 
@@ -27,9 +29,16 @@ func NewInput(batches []message.Batch) *Input {
 	return &Input{TChan: ts}
 }
 
-// Connected always returns true.
-func (f *Input) Connected() bool {
-	return true
+// ConnectionStatus returns the current connection activity.
+func (f *Input) ConnectionStatus() component.ConnectionStatuses {
+	if f.closed {
+		return component.ConnectionStatuses{
+			component.ConnectionClosed(component.NoopObservability()),
+		}
+	}
+	return component.ConnectionStatuses{
+		component.ConnectionActive(component.NoopObservability()),
+	}
 }
 
 // TransactionChan returns a transaction channel.
@@ -41,6 +50,7 @@ func (f *Input) TransactionChan() <-chan message.Transaction {
 func (f *Input) TriggerStopConsuming() {
 	f.closeOnce.Do(func() {
 		close(f.TChan)
+		f.closed = true
 	})
 }
 
@@ -48,6 +58,7 @@ func (f *Input) TriggerStopConsuming() {
 func (f *Input) TriggerCloseNow() {
 	f.closeOnce.Do(func() {
 		close(f.TChan)
+		f.closed = true
 	})
 }
 

--- a/internal/manager/mock/output.go
+++ b/internal/manager/mock/output.go
@@ -3,6 +3,7 @@ package mock
 import (
 	"context"
 
+	"github.com/redpanda-data/benthos/v4/internal/component"
 	"github.com/redpanda-data/benthos/v4/internal/message"
 )
 
@@ -14,9 +15,13 @@ func (o OutputWriter) WriteTransaction(ctx context.Context, t message.Transactio
 	return o(ctx, t)
 }
 
-// Connected always returns true.
-func (o OutputWriter) Connected() bool {
-	return true
+// ConnectionStatus returns the current status of the given component
+// connection. The result is a slice in order to accommodate higher order
+// components that wrap several others.
+func (o OutputWriter) ConnectionStatus() component.ConnectionStatuses {
+	return component.ConnectionStatuses{
+		component.ConnectionActive(component.NoopObservability()),
+	}
 }
 
 // TriggerStopConsuming does nothing.
@@ -38,9 +43,13 @@ type OutputChanneled struct {
 	TChan <-chan message.Transaction
 }
 
-// Connected returns true.
-func (m *OutputChanneled) Connected() bool {
-	return true
+// ConnectionStatus returns the current status of the given component
+// connection. The result is a slice in order to accommodate higher order
+// components that wrap several others.
+func (m *OutputChanneled) ConnectionStatus() component.ConnectionStatuses {
+	return component.ConnectionStatuses{
+		component.ConnectionActive(component.NoopObservability()),
+	}
 }
 
 // Consume sets the read channel. This implementation is NOT thread safe.

--- a/internal/manager/output_wrapper.go
+++ b/internal/manager/output_wrapper.go
@@ -45,10 +45,8 @@ func (w *outputWrapper) WriteTransaction(ctx context.Context, t message.Transact
 	return nil
 }
 
-// Connected returns a boolean indicating whether this output is currently
-// connected to its target.
-func (w *outputWrapper) Connected() bool {
-	return w.output.Connected()
+func (w *outputWrapper) ConnectionStatus() component.ConnectionStatuses {
+	return w.output.ConnectionStatus()
 }
 
 func (w *outputWrapper) TriggerStopConsuming() {

--- a/internal/stream/manager/type.go
+++ b/internal/stream/manager/type.go
@@ -125,6 +125,17 @@ var (
 
 //------------------------------------------------------------------------------
 
+// ConnectionStatus returns the aggregate connection status of all stream inputs
+// and outputs.
+func (m *Type) ConnectionStatus() (s component.ConnectionStatuses) {
+	m.lock.Lock()
+	for _, t := range m.streams {
+		s = append(s, t.strm.ConnectionStatus()...)
+	}
+	m.lock.Unlock()
+	return
+}
+
 // Create attempts to construct and run a new stream under a unique ID. If the
 // ID already exists an error is returned.
 func (m *Type) Create(id string, conf stream.Config) error {

--- a/internal/stream/type.go
+++ b/internal/stream/type.go
@@ -49,7 +49,8 @@ func New(conf Config, mgr bundle.NewManagement, opts ...func(*Type)) (*Type, err
 	}
 
 	healthCheck := func(w http.ResponseWriter, r *http.Request) {
-		inputConnected := t.inputLayer.Connected()
+		inputStatuses := t.inputLayer.ConnectionStatus()
+		inputConnected := inputStatuses.AllActive()
 		outputConnected := t.outputLayer.Connected()
 
 		if atomic.LoadUint32(&t.closed) == 1 {
@@ -92,7 +93,7 @@ func OptOnClose(onClose func()) func(*Type) {
 // IsReady returns a boolean indicating whether both the input and output layers
 // of the stream are connected.
 func (t *Type) IsReady() bool {
-	return t.inputLayer.Connected() && t.outputLayer.Connected()
+	return t.inputLayer.ConnectionStatus().AllActive() && t.outputLayer.Connected()
 }
 
 func (t *Type) start() (err error) {

--- a/internal/stream/type.go
+++ b/internal/stream/type.go
@@ -51,7 +51,9 @@ func New(conf Config, mgr bundle.NewManagement, opts ...func(*Type)) (*Type, err
 	healthCheck := func(w http.ResponseWriter, r *http.Request) {
 		inputStatuses := t.inputLayer.ConnectionStatus()
 		inputConnected := inputStatuses.AllActive()
-		outputConnected := t.outputLayer.Connected()
+
+		outputStatuses := t.outputLayer.ConnectionStatus()
+		outputConnected := outputStatuses.AllActive()
 
 		if atomic.LoadUint32(&t.closed) == 1 {
 			http.Error(w, "Stream terminated", http.StatusNotFound)
@@ -93,7 +95,7 @@ func OptOnClose(onClose func()) func(*Type) {
 // IsReady returns a boolean indicating whether both the input and output layers
 // of the stream are connected.
 func (t *Type) IsReady() bool {
-	return t.inputLayer.ConnectionStatus().AllActive() && t.outputLayer.Connected()
+	return t.inputLayer.ConnectionStatus().AllActive() && t.outputLayer.ConnectionStatus().AllActive()
 }
 
 func (t *Type) start() (err error) {

--- a/internal/stream/type.go
+++ b/internal/stream/type.go
@@ -10,6 +10,7 @@ import (
 	"time"
 
 	"github.com/redpanda-data/benthos/v4/internal/bundle"
+	"github.com/redpanda-data/benthos/v4/internal/component"
 	"github.com/redpanda-data/benthos/v4/internal/component/buffer"
 	"github.com/redpanda-data/benthos/v4/internal/component/input"
 	"github.com/redpanda-data/benthos/v4/internal/component/output"
@@ -96,6 +97,14 @@ func OptOnClose(onClose func()) func(*Type) {
 // of the stream are connected.
 func (t *Type) IsReady() bool {
 	return t.inputLayer.ConnectionStatus().AllActive() && t.outputLayer.ConnectionStatus().AllActive()
+}
+
+// ConnectionStatus returns the aggregate connection status of all inputs and
+// outputs of the stream.
+func (t *Type) ConnectionStatus() (s component.ConnectionStatuses) {
+	s = append(s, t.inputLayer.ConnectionStatus()...)
+	s = append(s, t.outputLayer.ConnectionStatus()...)
+	return
 }
 
 func (t *Type) start() (err error) {

--- a/public/service/service_test.go
+++ b/public/service/service_test.go
@@ -1,0 +1,92 @@
+package service_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	_ "github.com/redpanda-data/benthos/v4/public/components/io"
+	_ "github.com/redpanda-data/benthos/v4/public/components/pure"
+	"github.com/redpanda-data/benthos/v4/public/service"
+)
+
+func TestRunCLIShutdown(t *testing.T) {
+	tmpDir := t.TempDir()
+	confPath := filepath.Join(tmpDir, "foo.yaml")
+	outPath := filepath.Join(tmpDir, "out.txt")
+
+	require.NoError(t, os.WriteFile(confPath, fmt.Appendf(nil, `
+input:
+  generate:
+    mapping: 'root.id = "foobar"'
+    interval: "100ms"
+output:
+  file:
+    codec: lines
+    path: %v
+`, outPath), 0o644))
+
+	ctx, cancel := context.WithDeadline(context.Background(), time.Now().Add(time.Second))
+	defer cancel()
+
+	service.RunCLI(ctx, service.CLIOptSetArgs("benthos", "-c", confPath))
+
+	data, _ := os.ReadFile(outPath)
+	assert.Contains(t, string(data), "foobar")
+}
+
+func TestRunCLIConnectivityStatus(t *testing.T) {
+	tmpDir := t.TempDir()
+	confPath := filepath.Join(tmpDir, "foo.yaml")
+
+	require.NoError(t, os.WriteFile(confPath, []byte(`
+input:
+  label: inputa
+  generate:
+    mapping: 'root.id = "foobar"'
+    interval: "100ms"
+
+output:
+  label: outputa
+  drop: {}
+`), 0o644))
+
+	var summary atomic.Pointer[service.RunningStreamSummary]
+	go service.RunCLI(context.Background(),
+		service.CLIOptSetArgs("meow", "-c", confPath),
+		service.CLIOptOnStreamStart(func(s *service.RunningStreamSummary) error {
+			summary.Store(s)
+			return nil
+		}),
+	)
+
+	statusMap := map[string]bool{}
+	require.Eventually(t, func() bool {
+		tmp := summary.Load()
+		if tmp == nil {
+			return false
+		}
+
+		statuses := tmp.ConnectionStatuses()
+		if len(statuses) != 2 {
+			return false
+		}
+
+		for _, s := range statuses {
+			statusMap[s.Label()] = s.Active()
+		}
+		return true
+	}, time.Second, time.Millisecond*50)
+
+	assert.Equal(t, map[string]bool{
+		"inputa":  true,
+		"outputa": true,
+	}, statusMap)
+}

--- a/public/service/servicetest/service.go
+++ b/public/service/servicetest/service.go
@@ -21,6 +21,8 @@ import (
 // 2. A termination signal is received
 // 3. The provided context has a deadline that is reached, triggering graceful termination
 // 4. The provided context is cancelled (WARNING, this prevents graceful termination)
+//
+// Deprecated: Use the service.CLIOptSetArgs opt func instead.
 func RunCLIWithArgs(ctx context.Context, args ...string) {
 	if err := cli.App(common.NewCLIOpts(cli.Version, cli.DateBuilt)).RunContext(ctx, args); err != nil {
 		var cerr *common.ErrExitCode


### PR DESCRIPTION
This PR updates the CLI opt funcs to make it possible to poll for connectivity statuses of a running instance of benthos. I've also merged the changelog branch into this PR so we can cut a release immediately.