### PR TITLE
Fix switch output metrics labels

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ Changelog
 
 All notable changes to this project will be documented in this file.
 
+## 4.37.0 - TBD
+
+### Fixed
+
+- The `switch` output metrics now emit the case id as part of their labels. This is a regression introduced in v4.25.0. (@mihaitodor)
+
 ## 4.36.0 - 2024-08-29
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,12 +3,13 @@ Changelog
 
 All notable changes to this project will be documented in this file.
 
-## 4.37.0 - TBD
+## 4.37.0 - 2024-09-11
 
 ### Fixed
 
 - The `switch` output metrics now emit the case id as part of their labels. This is a regression introduced in v4.25.0. (@mihaitodor)
 - Fixed a bug where certain logs used the `%w` verb to print errors resulting in incorrect output. (@mihaitodor)
+- Fields instantiated via `FieldObjectList` and `FieldObjectMap` should now yield correct observability paths. (@Jeffail)
 
 ## 4.36.0 - 2024-08-29
 

--- a/internal/impl/pure/output_switch.go
+++ b/internal/impl/pure/output_switch.go
@@ -228,10 +228,11 @@ func switchOutputFromParsed(conf *service.ParsedConfig, mgr bundle.NewManagement
 	}
 
 	for i, cConf := range cases {
-		w, err := cConf.FieldOutput(soFieldCasesOutput)
+		w, err := conf.Namespace(soFieldCases).FieldOutput([]string{strconv.Itoa(i), soFieldCasesOutput}...)
 		if err != nil {
 			return nil, err
 		}
+
 		o.outputs[i] = interop.UnwrapOwnedOutput(w)
 
 		oMgr := mgr.IntoPath("switch", strconv.Itoa(i), "output")

--- a/internal/impl/pure/output_switch.go
+++ b/internal/impl/pure/output_switch.go
@@ -228,7 +228,7 @@ func switchOutputFromParsed(conf *service.ParsedConfig, mgr bundle.NewManagement
 	}
 
 	for i, cConf := range cases {
-		w, err := conf.Namespace(soFieldCases).FieldOutput([]string{strconv.Itoa(i), soFieldCasesOutput}...)
+		w, err := cConf.FieldOutput(soFieldCasesOutput)
 		if err != nil {
 			return nil, err
 		}

--- a/internal/impl/pure/output_switch_test.go
+++ b/internal/impl/pure/output_switch_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/redpanda-data/benthos/v4/internal/batch"
 	"github.com/redpanda-data/benthos/v4/internal/manager/mock"
 	"github.com/redpanda-data/benthos/v4/internal/message"
+	"github.com/redpanda-data/benthos/v4/public/service"
 )
 
 func newSwitch(t testing.TB, mockOutputs []*mock.OutputChanneled, confStr string, args ...any) *switchOutput {
@@ -1013,4 +1014,124 @@ bpLoop:
 	close(readChan)
 	close(doneChan)
 	wg.Wait()
+}
+
+type mockMetricsExporterType struct {
+	labels map[string][]string
+}
+
+func (m *mockMetricsExporterType) Timing(delta int64) {}
+
+func (m *mockMetricsExporterType) Set(value int64) {}
+
+func (m *mockMetricsExporterType) Incr(count int64) {}
+
+type mockMetricsExporter struct {
+	exporters []mockMetricsExporterType
+	lock      *sync.Mutex
+}
+
+func (m *mockMetricsExporter) Close(ctx context.Context) error {
+	return nil
+}
+
+func (m *mockMetricsExporter) NewCounterCtor(name string, labelKeys ...string) service.MetricsExporterCounterCtor {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+
+	exporter := mockMetricsExporterType{
+		labels: make(map[string][]string),
+	}
+	m.exporters = append(m.exporters, exporter)
+
+	return func(labelValues ...string) service.MetricsExporterCounter {
+		exporter.labels[name] = labelValues
+		return &exporter
+	}
+}
+
+func (m *mockMetricsExporter) NewGaugeCtor(name string, labelKeys ...string) service.MetricsExporterGaugeCtor {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+
+	exporter := mockMetricsExporterType{
+		labels: make(map[string][]string),
+	}
+	m.exporters = append(m.exporters, exporter)
+
+	return func(labelValues ...string) service.MetricsExporterGauge {
+		exporter.labels[name] = labelValues
+		return &exporter
+	}
+}
+
+func (m *mockMetricsExporter) NewTimerCtor(name string, labelKeys ...string) service.MetricsExporterTimerCtor {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+
+	exporter := mockMetricsExporterType{
+		labels: make(map[string][]string),
+	}
+	m.exporters = append(m.exporters, exporter)
+
+	return func(labelValues ...string) service.MetricsExporterTimer {
+		exporter.labels[name] = labelValues
+		return &exporter
+	}
+}
+
+func TestSwitchMetricsLabels(t *testing.T) {
+	metricsExporter := &mockMetricsExporter{
+		lock: &sync.Mutex{},
+	}
+
+	env := service.NewEnvironment()
+
+	require.NoError(t, env.RegisterMetricsExporter(
+		"meow", service.NewConfigSpec(),
+		func(conf *service.ParsedConfig, log *service.Logger) (service.MetricsExporter, error) {
+			return metricsExporter, nil
+		}))
+
+	builder := env.NewStreamBuilder()
+	require.NoError(t, builder.SetYAML(`
+input:
+  generate:
+    count: 2
+    interval: 0s
+    mapping: root.foo = counter()
+
+output:
+  switch:
+    cases:
+      - check: json("foo") == 1
+        output:
+          drop: {}
+      - check: json("foo") == 2
+        output:
+          drop: {}
+
+metrics:
+  meow: {}
+`))
+
+	strm, err := builder.Build()
+	require.NoError(t, err)
+
+	ctx, done := context.WithTimeout(context.Background(), 1*time.Second)
+	defer done()
+
+	require.NoError(t, strm.Run(ctx))
+
+	metricsExporter.lock.Lock()
+	defer metricsExporter.lock.Unlock()
+
+	var labels []string
+	for _, exporter := range metricsExporter.exporters {
+		for _, l := range exporter.labels {
+			labels = append(labels, l...)
+		}
+	}
+
+	assert.Subset(t, labels, []string{"root.output.switch.cases.0.output", "root.output.switch.cases.1.output"})
 }

--- a/public/service/config.go
+++ b/public/service/config.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"sort"
+	"strconv"
 	"time"
 
 	"github.com/redpanda-data/benthos/v4/internal/bundle"
@@ -695,7 +696,7 @@ func (p *ParsedConfig) FieldObjectList(path ...string) ([]*ParsedConfig, error) 
 	for i, v := range il {
 		pl[i] = &ParsedConfig{
 			i:   v,
-			mgr: p.mgr,
+			mgr: p.mgr.IntoPath(path...).IntoPath(strconv.Itoa(i)),
 		}
 	}
 	return pl, nil
@@ -715,7 +716,7 @@ func (p *ParsedConfig) FieldObjectMap(path ...string) (map[string]*ParsedConfig,
 	for k, v := range im {
 		pl[k] = &ParsedConfig{
 			i:   v,
-			mgr: p.mgr,
+			mgr: p.mgr.IntoPath(path...).IntoPath(k),
 		}
 	}
 	return pl, nil


### PR DESCRIPTION
Fixes #58 which is caused by a regression introduced in v4.25.0 via commit bc1ebafa9.