### PR TITLE
Add individual with env methods

### DIFF
--- a/internal/bundle/buffers.go
+++ b/internal/bundle/buffers.go
@@ -114,3 +114,20 @@ func (s *BufferSet) Without(names ...string) *BufferSet {
 	}
 	return newSet
 }
+
+// With creates a clone of the set including a variadic list of components.
+func (s *BufferSet) With(names ...string) *BufferSet {
+	newSet := &BufferSet{
+		specs: map[string]bufferSpec{},
+	}
+	nameMap := make(map[string]struct{}, len(names))
+	for _, n := range names {
+		nameMap[n] = struct{}{}
+	}
+	for k, v := range s.specs {
+		if _, exists := nameMap[k]; exists {
+			newSet.specs[k] = v
+		}
+	}
+	return newSet
+}

--- a/internal/bundle/caches.go
+++ b/internal/bundle/caches.go
@@ -114,3 +114,20 @@ func (s *CacheSet) Without(names ...string) *CacheSet {
 	}
 	return newSet
 }
+
+// With creates a clone of the set including a variadic list of components.
+func (s *CacheSet) With(names ...string) *CacheSet {
+	newSet := &CacheSet{
+		specs: map[string]cacheSpec{},
+	}
+	nameMap := make(map[string]struct{}, len(names))
+	for _, n := range names {
+		nameMap[n] = struct{}{}
+	}
+	for k, v := range s.specs {
+		if _, exists := nameMap[k]; exists {
+			newSet.specs[k] = v
+		}
+	}
+	return newSet
+}

--- a/internal/bundle/environment.go
+++ b/internal/bundle/environment.go
@@ -305,3 +305,75 @@ func (e *Environment) WithoutScanners(names ...string) *Environment {
 	newEnv.scanners = e.scanners.Without(names...)
 	return &newEnv
 }
+
+// WithBuffers returns a copy of Environment with a cloned plugin registry of
+// buffers, where only the specified plugins are included.
+func (e *Environment) WithBuffers(names ...string) *Environment {
+	newEnv := *e
+	newEnv.buffers = e.buffers.With(names...)
+	return &newEnv
+}
+
+// WithCaches returns a copy of Environment with a cloned plugin registry of
+// caches, where only the specified plugins are included.
+func (e *Environment) WithCaches(names ...string) *Environment {
+	newEnv := *e
+	newEnv.caches = e.caches.With(names...)
+	return &newEnv
+}
+
+// WithInputs returns a copy of Environment with a cloned plugin registry of
+// inputs, where only the specified plugins are included.
+func (e *Environment) WithInputs(names ...string) *Environment {
+	newEnv := *e
+	newEnv.inputs = e.inputs.With(names...)
+	return &newEnv
+}
+
+// WithOutputs returns a copy of Environment with a cloned plugin registry of
+// outputs, where only the specified plugins are included.
+func (e *Environment) WithOutputs(names ...string) *Environment {
+	newEnv := *e
+	newEnv.outputs = e.outputs.With(names...)
+	return &newEnv
+}
+
+// WithProcessors returns a copy of Environment with a cloned plugin registry
+// of processors, where only the specified plugins are included.
+func (e *Environment) WithProcessors(names ...string) *Environment {
+	newEnv := *e
+	newEnv.processors = e.processors.With(names...)
+	return &newEnv
+}
+
+// WithRateLimits returns a copy of Environment with a cloned plugin registry
+// of rate limits, where only the specified plugins are included.
+func (e *Environment) WithRateLimits(names ...string) *Environment {
+	newEnv := *e
+	newEnv.rateLimits = e.rateLimits.With(names...)
+	return &newEnv
+}
+
+// WithMetrics returns a copy of Environment with a cloned plugin registry of
+// metrics, where only the specified plugins are included.
+func (e *Environment) WithMetrics(names ...string) *Environment {
+	newEnv := *e
+	newEnv.metrics = e.metrics.With(names...)
+	return &newEnv
+}
+
+// WithTracers returns a copy of Environment with a cloned plugin registry of
+// tracers, where only the specified plugins are included.
+func (e *Environment) WithTracers(names ...string) *Environment {
+	newEnv := *e
+	newEnv.tracers = e.tracers.With(names...)
+	return &newEnv
+}
+
+// WithScanners returns a copy of Environment with a cloned plugin registry
+// of scanners, where only the specified plugins are included.
+func (e *Environment) WithScanners(names ...string) *Environment {
+	newEnv := *e
+	newEnv.scanners = e.scanners.With(names...)
+	return &newEnv
+}

--- a/internal/bundle/environment_test.go
+++ b/internal/bundle/environment_test.go
@@ -503,3 +503,170 @@ func TestEnvironmentWith(t *testing.T) {
 		assert.Contains(t, err.Error(), "was not recognised")
 	}
 }
+
+func TestEnvironmentIndividualWith(t *testing.T) {
+	env := bundle.NewEnvironment()
+
+	errTest := errors.New("exists")
+
+	for _, k := range []string{"foo", "bar", "baz"} {
+		require.NoError(t, env.BufferAdd(func(c buffer.Config, nm bundle.NewManagement) (buffer.Streamed, error) {
+			return nil, errTest
+		}, docs.ComponentSpec{Name: k + "buffer"}))
+
+		require.NoError(t, env.CacheAdd(func(c cache.Config, nm bundle.NewManagement) (cache.V1, error) {
+			return nil, errTest
+		}, docs.ComponentSpec{Name: k + "cache"}))
+
+		require.NoError(t, env.InputAdd(func(c input.Config, nm bundle.NewManagement) (input.Streamed, error) {
+			return nil, errTest
+		}, docs.ComponentSpec{Name: k + "input"}))
+
+		require.NoError(t, env.OutputAdd(func(c output.Config, nm bundle.NewManagement, pcf ...processor.PipelineConstructorFunc) (output.Streamed, error) {
+			return nil, errTest
+		}, docs.ComponentSpec{Name: k + "output"}))
+
+		require.NoError(t, env.ProcessorAdd(func(conf processor.Config, mgr bundle.NewManagement) (processor.V1, error) {
+			return nil, errTest
+		}, docs.ComponentSpec{Name: k + "processor"}))
+
+		require.NoError(t, env.RateLimitAdd(func(c ratelimit.Config, nm bundle.NewManagement) (ratelimit.V1, error) {
+			return nil, errTest
+		}, docs.ComponentSpec{Name: k + "ratelimit"}))
+
+		require.NoError(t, env.MetricsAdd(func(conf metrics.Config, nm bundle.NewManagement) (metrics.Type, error) {
+			return nil, errTest
+		}, docs.ComponentSpec{Name: k + "metric"}))
+
+		require.NoError(t, env.TracersAdd(func(c tracer.Config, nm bundle.NewManagement) (trace.TracerProvider, error) {
+			return nil, errTest
+		}, docs.ComponentSpec{Name: k + "tracer"}))
+
+		require.NoError(t, env.ScannerAdd(func(c scanner.Config, nm bundle.NewManagement) (scanner.Creator, error) {
+			return nil, errTest
+		}, docs.ComponentSpec{Name: k + "scanner"}))
+	}
+
+	env = env.
+		WithBuffers("barbuffer").
+		WithCaches("barcache").
+		WithInputs("barinput").
+		WithOutputs("baroutput").
+		WithProcessors("barprocessor").
+		WithRateLimits("barratelimit").
+		WithMetrics("barmetric").
+		WithTracers("bartracer").
+		WithScanners("barscanner")
+
+	for _, k := range []string{"bar"} {
+		bconf := buffer.NewConfig()
+		bconf.Type = k + "buffer"
+		_, err := env.BufferInit(bconf, mock.NewManager())
+		require.Error(t, err)
+		assert.ErrorIs(t, err, errTest)
+
+		cconf := cache.NewConfig()
+		cconf.Type = k + "cache"
+		_, err = env.CacheInit(cconf, mock.NewManager())
+		require.Error(t, err)
+		assert.ErrorIs(t, err, errTest)
+
+		iconf := input.NewConfig()
+		iconf.Type = k + "input"
+		_, err = env.InputInit(iconf, mock.NewManager())
+		require.Error(t, err)
+		assert.ErrorIs(t, err, errTest)
+
+		oconf := output.NewConfig()
+		oconf.Type = k + "output"
+		_, err = env.OutputInit(oconf, mock.NewManager())
+		require.Error(t, err)
+		assert.ErrorIs(t, err, errTest)
+
+		pconf := processor.NewConfig()
+		pconf.Type = k + "processor"
+		_, err = env.ProcessorInit(pconf, mock.NewManager())
+		require.Error(t, err)
+		assert.ErrorIs(t, err, errTest)
+
+		rconf := ratelimit.NewConfig()
+		rconf.Type = k + "ratelimit"
+		_, err = env.RateLimitInit(rconf, mock.NewManager())
+		require.Error(t, err)
+		assert.ErrorIs(t, err, errTest)
+
+		mconf := metrics.NewConfig()
+		mconf.Type = k + "metric"
+		_, err = env.MetricsInit(mconf, mock.NewManager())
+		require.Error(t, err)
+		assert.ErrorIs(t, err, errTest)
+
+		tconf := tracer.NewConfig()
+		tconf.Type = k + "tracer"
+		_, err = env.TracersInit(tconf, mock.NewManager())
+		require.Error(t, err)
+		assert.ErrorIs(t, err, errTest)
+
+		sconf := scanner.Config{}
+		sconf.Type = k + "scanner"
+		_, err = env.ScannerInit(sconf, mock.NewManager())
+		require.Error(t, err)
+		assert.ErrorIs(t, err, errTest)
+	}
+
+	for _, k := range []string{"foo", "baz"} {
+		bconf := buffer.NewConfig()
+		bconf.Type = k + "buffer"
+		_, err := env.BufferInit(bconf, mock.NewManager())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "was not recognised")
+
+		cconf := cache.NewConfig()
+		cconf.Type = k + "cache"
+		_, err = env.CacheInit(cconf, mock.NewManager())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "was not recognised")
+
+		iconf := input.NewConfig()
+		iconf.Type = k + "input"
+		_, err = env.InputInit(iconf, mock.NewManager())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "was not recognised")
+
+		oconf := output.NewConfig()
+		oconf.Type = k + "output"
+		_, err = env.OutputInit(oconf, mock.NewManager())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "was not recognised")
+
+		pconf := processor.NewConfig()
+		pconf.Type = k + "processor"
+		_, err = env.ProcessorInit(pconf, mock.NewManager())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "was not recognised")
+
+		rconf := ratelimit.NewConfig()
+		rconf.Type = k + "ratelimit"
+		_, err = env.RateLimitInit(rconf, mock.NewManager())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "was not recognised")
+
+		mconf := metrics.NewConfig()
+		mconf.Type = k + "metric"
+		_, err = env.MetricsInit(mconf, mock.NewManager())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "was not recognised")
+
+		tconf := tracer.NewConfig()
+		tconf.Type = k + "tracer"
+		_, err = env.TracersInit(tconf, mock.NewManager())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "was not recognised")
+
+		sconf := scanner.Config{}
+		sconf.Type = k + "scanner"
+		_, err = env.ScannerInit(sconf, mock.NewManager())
+		require.Error(t, err)
+		assert.Contains(t, err.Error(), "was not recognised")
+	}
+}

--- a/internal/bundle/inputs.go
+++ b/internal/bundle/inputs.go
@@ -113,3 +113,20 @@ func (s *InputSet) Without(names ...string) *InputSet {
 	}
 	return newSet
 }
+
+// With creates a clone of the set including a variadic list of components.
+func (s *InputSet) With(names ...string) *InputSet {
+	newSet := &InputSet{
+		specs: map[string]inputSpec{},
+	}
+	nameMap := make(map[string]struct{}, len(names))
+	for _, n := range names {
+		nameMap[n] = struct{}{}
+	}
+	for k, v := range s.specs {
+		if _, exists := nameMap[k]; exists {
+			newSet.specs[k] = v
+		}
+	}
+	return newSet
+}

--- a/internal/bundle/metrics.go
+++ b/internal/bundle/metrics.go
@@ -127,3 +127,20 @@ func (s *MetricsSet) Without(names ...string) *MetricsSet {
 	}
 	return newSet
 }
+
+// With creates a clone of the set including a variadic list of components.
+func (s *MetricsSet) With(names ...string) *MetricsSet {
+	newSet := &MetricsSet{
+		specs: map[string]metricsSpec{},
+	}
+	nameMap := make(map[string]struct{}, len(names))
+	for _, n := range names {
+		nameMap[n] = struct{}{}
+	}
+	for k, v := range s.specs {
+		if _, exists := nameMap[k]; exists {
+			newSet.specs[k] = v
+		}
+	}
+	return newSet
+}

--- a/internal/bundle/outputs.go
+++ b/internal/bundle/outputs.go
@@ -123,3 +123,20 @@ func (s *OutputSet) Without(names ...string) *OutputSet {
 	}
 	return newSet
 }
+
+// With creates a clone of the set including a variadic list of components.
+func (s *OutputSet) With(names ...string) *OutputSet {
+	newSet := &OutputSet{
+		specs: map[string]outputSpec{},
+	}
+	nameMap := make(map[string]struct{}, len(names))
+	for _, n := range names {
+		nameMap[n] = struct{}{}
+	}
+	for k, v := range s.specs {
+		if _, exists := nameMap[k]; exists {
+			newSet.specs[k] = v
+		}
+	}
+	return newSet
+}

--- a/internal/bundle/processors.go
+++ b/internal/bundle/processors.go
@@ -116,3 +116,20 @@ func (s *ProcessorSet) Without(names ...string) *ProcessorSet {
 	}
 	return newSet
 }
+
+// With creates a clone of the set including a variadic list of components.
+func (s *ProcessorSet) With(names ...string) *ProcessorSet {
+	newSet := &ProcessorSet{
+		specs: map[string]processorSpec{},
+	}
+	nameMap := make(map[string]struct{}, len(names))
+	for _, n := range names {
+		nameMap[n] = struct{}{}
+	}
+	for k, v := range s.specs {
+		if _, exists := nameMap[k]; exists {
+			newSet.specs[k] = v
+		}
+	}
+	return newSet
+}

--- a/internal/bundle/ratelimits.go
+++ b/internal/bundle/ratelimits.go
@@ -114,3 +114,20 @@ func (s *RateLimitSet) Without(names ...string) *RateLimitSet {
 	}
 	return newSet
 }
+
+// With creates a clone of the set including a variadic list of components.
+func (s *RateLimitSet) With(names ...string) *RateLimitSet {
+	newSet := &RateLimitSet{
+		specs: map[string]rateLimitSpec{},
+	}
+	nameMap := make(map[string]struct{}, len(names))
+	for _, n := range names {
+		nameMap[n] = struct{}{}
+	}
+	for k, v := range s.specs {
+		if _, exists := nameMap[k]; exists {
+			newSet.specs[k] = v
+		}
+	}
+	return newSet
+}

--- a/internal/bundle/scanners.go
+++ b/internal/bundle/scanners.go
@@ -113,3 +113,20 @@ func (s *ScannerSet) Without(names ...string) *ScannerSet {
 	}
 	return newSet
 }
+
+// With creates a clone of the set including a variadic list of components.
+func (s *ScannerSet) With(names ...string) *ScannerSet {
+	newSet := &ScannerSet{
+		specs: map[string]scannerSpec{},
+	}
+	nameMap := make(map[string]struct{}, len(names))
+	for _, n := range names {
+		nameMap[n] = struct{}{}
+	}
+	for k, v := range s.specs {
+		if _, exists := nameMap[k]; exists {
+			newSet.specs[k] = v
+		}
+	}
+	return newSet
+}

--- a/internal/bundle/tracers.go
+++ b/internal/bundle/tracers.go
@@ -114,3 +114,20 @@ func (s *TracerSet) Without(names ...string) *TracerSet {
 	}
 	return newSet
 }
+
+// With creates a clone of the set including a variadic list of components.
+func (s *TracerSet) With(names ...string) *TracerSet {
+	newSet := &TracerSet{
+		specs: map[string]tracerSpec{},
+	}
+	nameMap := make(map[string]struct{}, len(names))
+	for _, n := range names {
+		nameMap[n] = struct{}{}
+	}
+	for k, v := range s.specs {
+		if _, exists := nameMap[k]; exists {
+			newSet.specs[k] = v
+		}
+	}
+	return newSet
+}

--- a/public/service/environment.go
+++ b/public/service/environment.go
@@ -707,3 +707,95 @@ func (e *Environment) RegisterTemplateYAML(yamlStr string) error {
 func XFormatConfigJSON() ([]byte, error) {
 	return json.Marshal(config.Spec())
 }
+
+//------------------------------------------------------------------------------
+
+// WithBuffers returns a copy of Environment with a cloned plugin registry of
+// buffers, where only the specified plugins are included.
+func (e *Environment) WithBuffers(names ...string) *Environment {
+	return &Environment{
+		internal:    e.internal.WithBuffers(names...),
+		bloblangEnv: e.bloblangEnv.Clone(),
+		fs:          e.fs,
+	}
+}
+
+// WithCaches returns a copy of Environment with a cloned plugin registry of
+// caches, where only the specified plugins are included.
+func (e *Environment) WithCaches(names ...string) *Environment {
+	return &Environment{
+		internal:    e.internal.WithCaches(names...),
+		bloblangEnv: e.bloblangEnv.Clone(),
+		fs:          e.fs,
+	}
+}
+
+// WithInputs returns a copy of Environment with a cloned plugin registry of
+// inputs, where only the specified plugins are included.
+func (e *Environment) WithInputs(names ...string) *Environment {
+	return &Environment{
+		internal:    e.internal.WithInputs(names...),
+		bloblangEnv: e.bloblangEnv.Clone(),
+		fs:          e.fs,
+	}
+}
+
+// WithOutputs returns a copy of Environment with a cloned plugin registry of
+// outputs, where only the specified plugins are included.
+func (e *Environment) WithOutputs(names ...string) *Environment {
+	return &Environment{
+		internal:    e.internal.WithOutputs(names...),
+		bloblangEnv: e.bloblangEnv.Clone(),
+		fs:          e.fs,
+	}
+}
+
+// WithProcessors returns a copy of Environment with a cloned plugin registry
+// of processors, where only the specified plugins are included.
+func (e *Environment) WithProcessors(names ...string) *Environment {
+	return &Environment{
+		internal:    e.internal.WithProcessors(names...),
+		bloblangEnv: e.bloblangEnv.Clone(),
+		fs:          e.fs,
+	}
+}
+
+// WithRateLimits returns a copy of Environment with a cloned plugin registry
+// of rate limits, where only the specified plugins are included.
+func (e *Environment) WithRateLimits(names ...string) *Environment {
+	return &Environment{
+		internal:    e.internal.WithRateLimits(names...),
+		bloblangEnv: e.bloblangEnv.Clone(),
+		fs:          e.fs,
+	}
+}
+
+// WithMetrics returns a copy of Environment with a cloned plugin registry of
+// metrics, where only the specified plugins are included.
+func (e *Environment) WithMetrics(names ...string) *Environment {
+	return &Environment{
+		internal:    e.internal.WithMetrics(names...),
+		bloblangEnv: e.bloblangEnv.Clone(),
+		fs:          e.fs,
+	}
+}
+
+// WithTracers returns a copy of Environment with a cloned plugin registry of
+// tracers, where only the specified plugins are included.
+func (e *Environment) WithTracers(names ...string) *Environment {
+	return &Environment{
+		internal:    e.internal.WithTracers(names...),
+		bloblangEnv: e.bloblangEnv.Clone(),
+		fs:          e.fs,
+	}
+}
+
+// WithScanners returns a copy of Environment with a cloned plugin registry
+// of scanners, where only the specified plugins are included.
+func (e *Environment) WithScanners(names ...string) *Environment {
+	return &Environment{
+		internal:    e.internal.WithScanners(names...),
+		bloblangEnv: e.bloblangEnv.Clone(),
+		fs:          e.fs,
+	}
+}


### PR DESCRIPTION
This allows granular customisation of environment plugins for each component type. We'll need this for cloud builds as the more ambiguous call means we can't remove the `csv` input without losing the `csv` scanner.