### PR TITLE
Allow resources access from ParsedConfig

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ Changelog
 
 All notable changes to this project will be documented in this file.
 
+## 4.38.0 - 2024-09-17
+
+### Added
+
+- Go API: Method `Resources` added to the `ParsedConfig` type. (@Jeffail)
+
 ## 4.37.0 - 2024-09-11
 
 ### Fixed

--- a/internal/bloblang/query/functions.go
+++ b/internal/bloblang/query/functions.go
@@ -706,21 +706,21 @@ func randomIntFunction(args *ParsedParams) (Function, error) {
 	if err != nil {
 		return nil, err
 	}
-	min, err := args.FieldInt64("min")
+	minV, err := args.FieldInt64("min")
 	if err != nil {
 		return nil, err
 	}
-	max, err := args.FieldInt64("max")
+	maxV, err := args.FieldInt64("max")
 	if err != nil {
 		return nil, err
 	}
-	if min < 0 {
-		return nil, fmt.Errorf("min (%d) must be a positive number", min)
+	if minV < 0 {
+		return nil, fmt.Errorf("min (%d) must be a positive number", minV)
 	}
-	if max < min {
-		return nil, fmt.Errorf("min (%d) must be smaller or equal than max (%d)", min, max)
+	if maxV < minV {
+		return nil, fmt.Errorf("min (%d) must be smaller or equal than max (%d)", minV, maxV)
 	}
-	if max == math.MaxInt64 {
+	if maxV == math.MaxInt64 {
 		return nil, fmt.Errorf("max must be smaller than the max allowed for an int64 (%d)", uint64(math.MaxInt64))
 	}
 	var randMut sync.Mutex
@@ -744,7 +744,7 @@ func randomIntFunction(args *ParsedParams) (Function, error) {
 			r = rand.New(rand.NewSource(seed))
 		}
 		// Int63n generates a random number within a half-open interval [0,n)
-		v := r.Int63n(max-min+1) + min
+		v := r.Int63n(maxV-minV+1) + minV
 		return v, nil
 	}, nil), nil
 }

--- a/internal/bloblang/query/functions_test.go
+++ b/internal/bloblang/query/functions_test.go
@@ -456,16 +456,16 @@ func TestRandomIntDynamicParallel(t *testing.T) {
 func TestRandomIntWithinRange(t *testing.T) {
 	tsFn, err := InitFunctionHelper("timestamp_unix_nano")
 	require.NoError(t, err)
-	var min, max int64 = 10, 20
-	e, err := InitFunctionHelper("random_int", tsFn, min, max)
+	var minV, maxV int64 = 10, 20
+	e, err := InitFunctionHelper("random_int", tsFn, minV, maxV)
 	require.NoError(t, err)
 
 	for i := 0; i < 1000; i++ {
 		res, err := e.Exec(FunctionContext{})
 		require.NoError(t, err)
 		require.IsType(t, int64(0), res)
-		assert.GreaterOrEqual(t, res.(int64), min)
-		assert.LessOrEqual(t, res.(int64), max)
+		assert.GreaterOrEqual(t, res.(int64), minV)
+		assert.LessOrEqual(t, res.(int64), maxV)
 	}
 
 	// Create a new random_int function with one single possible value

--- a/internal/bloblang/query/methods_numbers.go
+++ b/internal/bloblang/query/methods_numbers.go
@@ -145,17 +145,17 @@ var _ = registerSimpleMethod(
 			if len(arr) == 0 {
 				return nil, errors.New("the array was empty")
 			}
-			var max float64
+			var maxV float64
 			for i, n := range arr {
 				f, err := value.IGetNumber(n)
 				if err != nil {
 					return nil, fmt.Errorf("index %v of array: %w", i, err)
 				}
-				if i == 0 || f > max {
-					max = f
+				if i == 0 || f > maxV {
+					maxV = f
 				}
 			}
-			return max, nil
+			return maxV, nil
 		}, nil
 	},
 )
@@ -188,17 +188,17 @@ var _ = registerSimpleMethod(
 			if len(arr) == 0 {
 				return nil, errors.New("the array was empty")
 			}
-			var max float64
+			var maxV float64
 			for i, n := range arr {
 				f, err := value.IGetNumber(n)
 				if err != nil {
 					return nil, fmt.Errorf("index %v of array: %w", i, err)
 				}
-				if i == 0 || f < max {
-					max = f
+				if i == 0 || f < maxV {
+					maxV = f
 				}
 			}
-			return max, nil
+			return maxV, nil
 		}, nil
 	},
 )

--- a/internal/cli/studio/pull_runner_test.go
+++ b/internal/cli/studio/pull_runner_test.go
@@ -59,7 +59,7 @@ func testServerForPullRunner(
 		}
 	}
 	testServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		require.NotEmpty(t, len(expectedRequests))
+		require.NotEmpty(t, expectedRequests)
 
 		expReq := expectedRequests[0]
 		expectedRequests = expectedRequests[1:]

--- a/internal/codec/skip_group_reader.go
+++ b/internal/codec/skip_group_reader.go
@@ -49,15 +49,15 @@ groupLoop:
 	}
 }
 
-func readUpToMax(r io.Reader, max int) (buf []byte, err error) {
-	if max == 0 {
+func readUpToMax(r io.Reader, maxV int) (buf []byte, err error) {
+	if maxV == 0 {
 		return
 	}
 
-	buf = make([]byte, max)
+	buf = make([]byte, maxV)
 
 	var readLen int
-	for err == nil && readLen < max {
+	for err == nil && readLen < maxV {
 		var n int
 		n, err = r.Read(buf[readLen:])
 		readLen += n

--- a/internal/component/metrics/namespaced.go
+++ b/internal/component/metrics/namespaced.go
@@ -78,7 +78,7 @@ func (n *Namespaced) HandlerFunc() http.HandlerFunc {
 
 func (n *Namespaced) getPathAndLabels(path string) (newPath string, labelKeys, labelValues []string) {
 	newPath = path
-	if n.labels != nil && len(n.labels) > 0 {
+	if len(n.labels) > 0 {
 		labelKeys = make([]string, 0, len(n.labels))
 		for k := range n.labels {
 			labelKeys = append(labelKeys, k)

--- a/internal/component/testutil/from_yaml.go
+++ b/internal/component/testutil/from_yaml.go
@@ -1,8 +1,6 @@
 package testutil
 
 import (
-	"fmt"
-
 	"github.com/redpanda-data/benthos/v4/internal/bundle"
 	"github.com/redpanda-data/benthos/v4/internal/component/buffer"
 	"github.com/redpanda-data/benthos/v4/internal/component/cache"
@@ -20,8 +18,8 @@ import (
 
 // BufferFromYAML attempts to parse a config string and returns a buffer config
 // if successful or an error otherwise.
-func BufferFromYAML(confStr string, args ...any) (buffer.Config, error) {
-	node, err := docs.UnmarshalYAML(fmt.Appendf(nil, confStr, args...))
+func BufferFromYAML(confStr string) (buffer.Config, error) {
+	node, err := docs.UnmarshalYAML([]byte(confStr))
 	if err != nil {
 		return buffer.Config{}, err
 	}
@@ -30,8 +28,8 @@ func BufferFromYAML(confStr string, args ...any) (buffer.Config, error) {
 
 // CacheFromYAML attempts to parse a config string and returns a cache config
 // if successful or an error otherwise.
-func CacheFromYAML(confStr string, args ...any) (cache.Config, error) {
-	node, err := docs.UnmarshalYAML(fmt.Appendf(nil, confStr, args...))
+func CacheFromYAML(confStr string) (cache.Config, error) {
+	node, err := docs.UnmarshalYAML([]byte(confStr))
 	if err != nil {
 		return cache.Config{}, err
 	}
@@ -40,8 +38,8 @@ func CacheFromYAML(confStr string, args ...any) (cache.Config, error) {
 
 // InputFromYAML attempts to parse a config string and returns an input config
 // if successful or an error otherwise.
-func InputFromYAML(confStr string, args ...any) (input.Config, error) {
-	node, err := docs.UnmarshalYAML(fmt.Appendf(nil, confStr, args...))
+func InputFromYAML(confStr string) (input.Config, error) {
+	node, err := docs.UnmarshalYAML([]byte(confStr))
 	if err != nil {
 		return input.Config{}, err
 	}
@@ -50,8 +48,8 @@ func InputFromYAML(confStr string, args ...any) (input.Config, error) {
 
 // MetricsFromYAML attempts to parse a config string and returns a metrics
 // config if successful or an error otherwise.
-func MetricsFromYAML(confStr string, args ...any) (metrics.Config, error) {
-	node, err := docs.UnmarshalYAML(fmt.Appendf(nil, confStr, args...))
+func MetricsFromYAML(confStr string) (metrics.Config, error) {
+	node, err := docs.UnmarshalYAML([]byte(confStr))
 	if err != nil {
 		return metrics.Config{}, err
 	}
@@ -60,8 +58,8 @@ func MetricsFromYAML(confStr string, args ...any) (metrics.Config, error) {
 
 // OutputFromYAML attempts to parse a config string and returns an output config
 // if successful or an error otherwise.
-func OutputFromYAML(confStr string, args ...any) (output.Config, error) {
-	node, err := docs.UnmarshalYAML(fmt.Appendf(nil, confStr, args...))
+func OutputFromYAML(confStr string) (output.Config, error) {
+	node, err := docs.UnmarshalYAML([]byte(confStr))
 	if err != nil {
 		return output.Config{}, err
 	}
@@ -70,8 +68,8 @@ func OutputFromYAML(confStr string, args ...any) (output.Config, error) {
 
 // ProcessorFromYAML attempts to parse a config string and returns a processor
 // config if successful or an error otherwise.
-func ProcessorFromYAML(confStr string, args ...any) (processor.Config, error) {
-	node, err := docs.UnmarshalYAML(fmt.Appendf(nil, confStr, args...))
+func ProcessorFromYAML(confStr string) (processor.Config, error) {
+	node, err := docs.UnmarshalYAML([]byte(confStr))
 	if err != nil {
 		return processor.Config{}, err
 	}
@@ -80,8 +78,8 @@ func ProcessorFromYAML(confStr string, args ...any) (processor.Config, error) {
 
 // RateLimitFromYAML attempts to parse a config string and returns a ratelimit
 // config if successful or an error otherwise.
-func RateLimitFromYAML(confStr string, args ...any) (ratelimit.Config, error) {
-	node, err := docs.UnmarshalYAML(fmt.Appendf(nil, confStr, args...))
+func RateLimitFromYAML(confStr string) (ratelimit.Config, error) {
+	node, err := docs.UnmarshalYAML([]byte(confStr))
 	if err != nil {
 		return ratelimit.Config{}, err
 	}
@@ -90,8 +88,8 @@ func RateLimitFromYAML(confStr string, args ...any) (ratelimit.Config, error) {
 
 // TracerFromYAML attempts to parse a config string and returns a tracer config
 // if successful or an error otherwise.
-func TracerFromYAML(confStr string, args ...any) (tracer.Config, error) {
-	node, err := docs.UnmarshalYAML(fmt.Appendf(nil, confStr, args...))
+func TracerFromYAML(confStr string) (tracer.Config, error) {
+	node, err := docs.UnmarshalYAML([]byte(confStr))
 	if err != nil {
 		return tracer.Config{}, err
 	}
@@ -100,8 +98,8 @@ func TracerFromYAML(confStr string, args ...any) (tracer.Config, error) {
 
 // ManagerFromYAML attempts to parse a config string and returns a manager
 // config if successful or an error otherwise.
-func ManagerFromYAML(confStr string, args ...any) (manager.ResourceConfig, error) {
-	node, err := docs.UnmarshalYAML(fmt.Appendf(nil, confStr, args...))
+func ManagerFromYAML(confStr string) (manager.ResourceConfig, error) {
+	node, err := docs.UnmarshalYAML([]byte(confStr))
 	if err != nil {
 		return manager.ResourceConfig{}, err
 	}
@@ -110,8 +108,8 @@ func ManagerFromYAML(confStr string, args ...any) (manager.ResourceConfig, error
 
 // StreamFromYAML attempts to parse a config string and returns a stream config
 // if successful or an error otherwise.
-func StreamFromYAML(confStr string, args ...any) (stream.Config, error) {
-	node, err := docs.UnmarshalYAML(fmt.Appendf(nil, confStr, args...))
+func StreamFromYAML(confStr string) (stream.Config, error) {
+	node, err := docs.UnmarshalYAML([]byte(confStr))
 	if err != nil {
 		return stream.Config{}, err
 	}
@@ -128,8 +126,8 @@ func StreamFromYAML(confStr string, args ...any) (stream.Config, error) {
 
 // ConfigFromYAML attempts to parse a config string and returns a Benthos
 // service config if successful or an error otherwise.
-func ConfigFromYAML(confStr string, args ...any) (config.Type, error) {
-	node, err := docs.UnmarshalYAML(fmt.Appendf(nil, confStr, args...))
+func ConfigFromYAML(confStr string) (config.Type, error) {
+	node, err := docs.UnmarshalYAML([]byte(confStr))
 	if err != nil {
 		return config.Type{}, err
 	}

--- a/internal/impl/io/bloblang_test.go
+++ b/internal/impl/io/bloblang_test.go
@@ -14,10 +14,7 @@ import (
 
 func TestEnvFunctionCaching(t *testing.T) {
 	key := "BENTHOS_TEST_BLOBLANG_FUNCTION"
-	require.NoError(t, os.Setenv(key, "foobar"))
-	t.Cleanup(func() {
-		os.Unsetenv(key)
-	})
+	t.Setenv(key, "foobar")
 
 	eCached, err := query.InitFunctionHelper("env", key)
 	require.NoError(t, err)
@@ -33,7 +30,7 @@ func TestEnvFunctionCaching(t *testing.T) {
 	require.NoError(t, err)
 	assert.Equal(t, "foobar", res)
 
-	require.NoError(t, os.Setenv(key, "barbaz"))
+	t.Setenv(key, "barbaz")
 
 	res, err = eCached.Exec(query.FunctionContext{})
 	require.NoError(t, err)

--- a/internal/impl/pure/bloblang_general.go
+++ b/internal/impl/pure/bloblang_general.go
@@ -99,7 +99,7 @@ root.woof_id = null.apply("foos")
 				return nil, err
 			}
 
-			var min, max int64
+			var minV, maxV int64
 			var i *int64
 
 			var mut sync.Mutex
@@ -110,20 +110,20 @@ root.woof_id = null.apply("foos")
 
 				if i == nil {
 					var err error
-					if min, err = ctx.ExecToInt64(minFunc); err != nil {
+					if minV, err = ctx.ExecToInt64(minFunc); err != nil {
 						return nil, fmt.Errorf("failed to resolve min argument: %w", err)
 					}
-					if min < 0 {
-						return nil, fmt.Errorf("min argument must be >0, got %v", min)
+					if minV < 0 {
+						return nil, fmt.Errorf("min argument must be >0, got %v", minV)
 					}
-					if max, err = ctx.ExecToInt64(maxFunc); err != nil {
+					if maxV, err = ctx.ExecToInt64(maxFunc); err != nil {
 						return nil, fmt.Errorf("failed to resolve max argument: %w", err)
 					}
-					if max < 0 || max <= min {
-						return nil, fmt.Errorf("max argument must be >0 and >min, got %v", max)
+					if maxV < 0 || maxV <= minV {
+						return nil, fmt.Errorf("max argument must be >0 and >min, got %v", maxV)
 					}
 
-					iV := min - 1
+					iV := minV - 1
 					i = &iV
 				}
 
@@ -137,7 +137,7 @@ root.woof_id = null.apply("foos")
 					}
 					switch setV.(type) {
 					case bloblang.ExecResultDelete:
-						*i = min - 1
+						*i = minV - 1
 					case bloblang.ExecResultNothing:
 					default:
 						iv, err := value.IGetInt(setV)
@@ -151,8 +151,8 @@ root.woof_id = null.apply("foos")
 
 				*i++
 				v := *i
-				if v >= max {
-					*i = min - 1
+				if v >= maxV {
+					*i = minV - 1
 				}
 				return v, nil
 			}, nil

--- a/internal/impl/pure/input_sequence_test.go
+++ b/internal/impl/pure/input_sequence_test.go
@@ -25,8 +25,12 @@ func writeFiles(t *testing.T, dir string, nameToContent map[string]string) {
 	}
 }
 
-func testInput(t testing.TB, confPattern string, args ...any) input.Streamed {
-	iConf, err := testutil.InputFromYAML(fmt.Sprintf(confPattern, args...))
+func testInputf(t testing.TB, confPattern string, args ...any) input.Streamed {
+	return testInput(t, fmt.Sprintf(confPattern, args...))
+}
+
+func testInput(t testing.TB, confStr string) input.Streamed {
+	iConf, err := testutil.InputFromYAML(confStr)
 	require.NoError(t, err)
 
 	i, err := mock.NewManager().NewInput(iConf)
@@ -51,7 +55,7 @@ func TestSequenceHappy(t *testing.T) {
 
 	writeFiles(t, tmpDir, files)
 
-	rdr := testInput(t, `
+	rdr := testInputf(t, `
 sequence:
   inputs:
     - file:
@@ -109,7 +113,7 @@ func TestSequenceJoins(t *testing.T) {
 
 	writeFiles(t, tmpDir, files)
 
-	rdr := testInput(t, `
+	rdr := testInputf(t, `
 sequence:
   sharded_join:
     type: full-outer
@@ -333,7 +337,7 @@ func TestSequenceJoinsBig(t *testing.T) {
 	require.NoError(t, ndjsonFile.Close())
 	require.NoError(t, csvFile.Close())
 
-	rdr := testInput(t, `
+	rdr := testInputf(t, `
 sequence:
   sharded_join:
     type: full-outer

--- a/internal/impl/pure/output_drop_on_test.go
+++ b/internal/impl/pure/output_drop_on_test.go
@@ -23,9 +23,13 @@ import (
 	_ "github.com/redpanda-data/benthos/v4/public/components/pure"
 )
 
-func parseYAMLOutputConf(t testing.TB, formatStr string, args ...any) output.Config {
+func parseYAMLOutputConff(t testing.TB, formatStr string, args ...any) output.Config {
+	return parseYAMLOutputConf(t, fmt.Sprintf(formatStr, args...))
+}
+
+func parseYAMLOutputConf(t testing.TB, confStr string) output.Config {
 	t.Helper()
-	conf, err := testutil.OutputFromYAML(fmt.Sprintf(formatStr, args...))
+	conf, err := testutil.OutputFromYAML(confStr)
 	require.NoError(t, err)
 	return conf
 }
@@ -38,7 +42,7 @@ func TestDropOnNothing(t *testing.T) {
 		ts.Close()
 	})
 
-	dropConf := parseYAMLOutputConf(t, `
+	dropConf := parseYAMLOutputConff(t, `
 drop_on:
   error: false
   output:
@@ -85,7 +89,7 @@ func TestDropOnError(t *testing.T) {
 		ts.Close()
 	})
 
-	dropConf := parseYAMLOutputConf(t, `
+	dropConf := parseYAMLOutputConff(t, `
 drop_on:
   error: true
   output:
@@ -162,7 +166,7 @@ func TestDropOnBackpressureWithErrors(t *testing.T) {
 		ts.Close()
 	})
 
-	dropConf := parseYAMLOutputConf(t, `
+	dropConf := parseYAMLOutputConff(t, `
 drop_on:
   back_pressure: 100ms
   output:
@@ -250,7 +254,7 @@ func TestDropOnDisconnectBackpressureNoErrors(t *testing.T) {
 		ts.Close()
 	})
 
-	dropConf := parseYAMLOutputConf(t, `
+	dropConf := parseYAMLOutputConff(t, `
 drop_on:
   back_pressure: 100ms
   error: true
@@ -320,7 +324,7 @@ func TestDropOnErrorMatches(t *testing.T) {
 		ts.Close()
 	})
 
-	dropConf := parseYAMLOutputConf(t, `
+	dropConf := parseYAMLOutputConff(t, `
 drop_on:
   error_patterns:
     - foobar

--- a/internal/impl/pure/output_switch_test.go
+++ b/internal/impl/pure/output_switch_test.go
@@ -18,12 +18,12 @@ import (
 	"github.com/redpanda-data/benthos/v4/public/service"
 )
 
-func newSwitch(t testing.TB, mockOutputs []*mock.OutputChanneled, confStr string, args ...any) *switchOutput {
+func newSwitch(t testing.TB, mockOutputs []*mock.OutputChanneled, confStr string) *switchOutput {
 	t.Helper()
 
 	mgr := mock.NewManager()
 
-	pConf, err := switchOutputSpec().ParseYAML(fmt.Sprintf(confStr, args...), nil)
+	pConf, err := switchOutputSpec().ParseYAML(confStr, nil)
 	require.NoError(t, err)
 
 	s, err := switchOutputFromParsed(pConf, mgr)
@@ -172,7 +172,7 @@ func TestSwitchBatchNoRetries(t *testing.T) {
 	confStr := `
 retry_until_success: false
 cases:
-  - check: 'root = this.id %% 2 == 0'
+  - check: 'root = this.id % 2 == 0'
     output:
       drop: {}
   - check: 'root = true'

--- a/internal/impl/pure/processor_grok_test.go
+++ b/internal/impl/pure/processor_grok_test.go
@@ -2,6 +2,7 @@ package pure_test
 
 import (
 	"context"
+	"fmt"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -20,7 +21,7 @@ func TestGrokAllParts(t *testing.T) {
 	conf, err := testutil.ProcessorFromYAML(`
 grok:
   expressions:
-    - "%%{WORD:first},%%{INT:second:int}"
+    - "%{WORD:first},%{INT:second:int}"
 `)
 	require.NoError(t, err)
 
@@ -91,12 +92,12 @@ func TestGrok(t *testing.T) {
 			if test.definitions == nil {
 				test.definitions = map[string]any{}
 			}
-			conf, err := testutil.ProcessorFromYAML(`
+			conf, err := testutil.ProcessorFromYAML(fmt.Sprintf(`
 grok:
   expressions:
     - '%v'
   pattern_definitions: %v
-`, test.pattern, gabs.Wrap(test.definitions).String())
+`, test.pattern, gabs.Wrap(test.definitions).String()))
 			require.NoError(t, err)
 
 			gSet, err := mock.NewManager().NewProcessor(conf)
@@ -115,12 +116,12 @@ grok:
 			if test.definitions == nil {
 				test.definitions = map[string]any{}
 			}
-			conf, err := testutil.ProcessorFromYAML(`
+			conf, err := testutil.ProcessorFromYAML(fmt.Sprintf(`
 grok:
   expressions:
     - '%v'
   pattern_definitions: %v
-`, test.pattern, gabs.Wrap(test.definitions).String())
+`, test.pattern, gabs.Wrap(test.definitions).String()))
 			require.NoError(t, err)
 
 			gSet, err := mock.NewManager().NewProcessor(conf)
@@ -144,13 +145,13 @@ FOONESTED %{INT:nested.first:int} %{WORD:nested.second} %{WORD:nested.third}
 `), 0o777)
 	require.NoError(t, err)
 
-	conf, err := testutil.ProcessorFromYAML(`
+	conf, err := testutil.ProcessorFromYAML(fmt.Sprintf(`
 grok:
   expressions:
     - "%%{FOONESTED}"
     - "%%{FOOFLAT}"
   pattern_paths: [ %v ]
-`, tmpDir)
+`, tmpDir))
 	require.NoError(t, err)
 
 	gSet, err := mock.NewManager().NewProcessor(conf)

--- a/internal/impl/pure/processor_parallel.go
+++ b/internal/impl/pure/processor_parallel.go
@@ -68,16 +68,16 @@ func (p *parallelProc) ProcessBatch(ctx *processor.BatchProcContext, msg message
 		return nil
 	})
 
-	max := p.cap
-	if max == 0 || msg.Len() < max {
-		max = msg.Len()
+	maxV := p.cap
+	if maxV == 0 || msg.Len() < maxV {
+		maxV = msg.Len()
 	}
 
 	reqChan := make(chan int)
 	wg := sync.WaitGroup{}
-	wg.Add(max)
+	wg.Add(maxV)
 
-	for i := 0; i < max; i++ {
+	for i := 0; i < maxV; i++ {
 		go func() {
 			defer wg.Done()
 

--- a/internal/impl/pure/scanner_skip_bom.go
+++ b/internal/impl/pure/scanner_skip_bom.go
@@ -99,15 +99,15 @@ groupLoop:
 	}
 }
 
-func readUpToMax(r io.Reader, max int) (buf []byte, err error) {
-	if max == 0 {
+func readUpToMax(r io.Reader, maxV int) (buf []byte, err error) {
+	if maxV == 0 {
 		return
 	}
 
-	buf = make([]byte, max)
+	buf = make([]byte, maxV)
 
 	var readLen int
-	for err == nil && readLen < max {
+	for err == nil && readLen < maxV {
 		var n int
 		n, err = r.Read(buf[readLen:])
 		readLen += n

--- a/public/service/config.go
+++ b/public/service/config.go
@@ -539,6 +539,13 @@ func (p *ParsedConfig) EngineVersion() string {
 	return p.mgr.EngineVersion()
 }
 
+// Resources returns the resources type that has been granted to the given
+// parsed config view. Plugin implementations should generally only access and
+// preserve the resources reference they are granted in their constructors.
+func (p *ParsedConfig) Resources() *Resources {
+	return newResourcesFromManager(p.mgr)
+}
+
 // Namespace returns a version of the parsed config at a given field namespace.
 // This is useful for extracting multiple fields under the same grouping.
 func (p *ParsedConfig) Namespace(path ...string) *ParsedConfig {


### PR DESCRIPTION
Traditionally the `ParsedConfig` type is only used for accessing fields. However, it actually retains a reference to the underlying resources type which is used for instanciating more component types throughout the config. Since it's there anyway I've decided to allow you to access it with a public method and I'm planning to use this in our redpanda inputs and outputs.