### PR TITLE
Fix consecutive calls to AsStructuredMut

### DIFF
--- a/internal/message/data.go
+++ b/internal/message/data.go
@@ -71,7 +71,7 @@ func (m *messageData) AsStructuredMut() (any, error) {
 		if m.structured != nil {
 			m.structured = cloneGeneric(m.structured)
 		}
-		m.readOnlyStructured = true
+		m.readOnlyStructured = false
 	}
 
 	v, err := m.AsStructured()

--- a/internal/message/data_test.go
+++ b/internal/message/data_test.go
@@ -92,6 +92,15 @@ func TestConcurrentMutationsFromStructured(t *testing.T) {
 
 			vBytes := local.AsBytes()
 			assert.Equal(t, `{"foo":"baz"}`, string(vBytes))
+
+			vThingMore, err := local.AsStructuredMut()
+			require.NoError(t, err)
+
+			_, err = gabs.Wrap(vThingMore).Set("meow", "foo")
+			require.NoError(t, err)
+
+			vBytes = local.AsBytes()
+			assert.Equal(t, `{"foo":"meow"}`, string(vBytes))
 		}()
 	}
 


### PR DESCRIPTION
There's an optimisation where we're able to avoid performing deep copies when we know that the source message is already deep copied from an original. This fix enables this optimisation by fixing a redundant assignment bug.