### PR TITLE
Add custom cli flags

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 - Field `follow_redirects` added to the `http` processor. (@ooesili)
+- Go API: Cli opt function added for custom CLI flags. (@Jeffail)
 
 ## 4.39.0 - 2024-10-14
 

--- a/internal/cli/common/opts.go
+++ b/internal/cli/common/opts.go
@@ -13,6 +13,7 @@ import (
 	"github.com/redpanda-data/benthos/v4/internal/config"
 	"github.com/redpanda-data/benthos/v4/internal/docs"
 	"github.com/redpanda-data/benthos/v4/internal/log"
+	"github.com/urfave/cli/v2"
 )
 
 // StreamInitFunc is an optional func to be called when a stream (or streams
@@ -44,6 +45,9 @@ type CLIOpts struct {
 	OnLoggerInit         func(l log.Modular) (log.Modular, error)
 
 	OnStreamInit StreamInitFunc
+
+	CustomRunFlags     []cli.Flag
+	CustomRunExtractFn func(*cli.Context) error
 }
 
 // NewCLIOpts returns a new CLIOpts instance populated with default values.
@@ -78,7 +82,8 @@ func NewCLIOpts(version, dateBuilt string) *CLIOpts {
 		OnLoggerInit: func(l log.Modular) (log.Modular, error) {
 			return l, nil
 		},
-		OnStreamInit: func(s RunningStream) error { return nil },
+		OnStreamInit:       func(s RunningStream) error { return nil },
+		CustomRunExtractFn: func(*cli.Context) error { return nil },
 	}
 }
 

--- a/internal/cli/common/opts.go
+++ b/internal/cli/common/opts.go
@@ -8,12 +8,13 @@ import (
 	"path"
 	"text/template"
 
+	"github.com/urfave/cli/v2"
+
 	"github.com/redpanda-data/benthos/v4/internal/bloblang"
 	"github.com/redpanda-data/benthos/v4/internal/bundle"
 	"github.com/redpanda-data/benthos/v4/internal/config"
 	"github.com/redpanda-data/benthos/v4/internal/docs"
 	"github.com/redpanda-data/benthos/v4/internal/log"
-	"github.com/urfave/cli/v2"
 )
 
 // StreamInitFunc is an optional func to be called when a stream (or streams

--- a/internal/cli/common/run_flags.go
+++ b/internal/cli/common/run_flags.go
@@ -105,7 +105,7 @@ const (
 // RunFlags is the full set of root level flags that have been deprecated and
 // are now documented at each subcommand that requires them.
 func RunFlags(opts *CLIOpts, hidden bool) []cli.Flag {
-	return []cli.Flag{
+	f := []cli.Flag{
 		&cli.StringFlag{
 			Name:   RootFlagLogLevel,
 			Hidden: hidden,
@@ -138,6 +138,12 @@ func RunFlags(opts *CLIOpts, hidden bool) []cli.Flag {
 			Usage:   "EXPERIMENTAL: watch config files for changes and automatically apply them",
 		},
 	}
+	if hidden {
+		return f
+	}
+
+	// Only add custom flags when not hidden
+	return append(f, opts.CustomRunFlags...)
 }
 
 // EnvFileAndTemplateFlags represents env file and template flags that are used

--- a/internal/cli/common/service.go
+++ b/internal/cli/common/service.go
@@ -38,6 +38,10 @@ func (e *ErrExitCode) Unwrap() error {
 // RunService runs a service command (either the default or the streams
 // subcommand).
 func RunService(c *cli.Context, cliOpts *CLIOpts, streamsMode bool) error {
+	if err := cliOpts.CustomRunExtractFn(c); err != nil {
+		return err
+	}
+
 	mainPath, inferredMainPath, confReader := ReadConfig(c, cliOpts, streamsMode)
 
 	conf, pConf, lints, err := confReader.Read()

--- a/public/service/service.go
+++ b/public/service/service.go
@@ -7,13 +7,14 @@ import (
 	"log/slog"
 	"os"
 
+	ucli "github.com/urfave/cli/v2"
+
 	"github.com/redpanda-data/benthos/v4/internal/bloblang"
 	"github.com/redpanda-data/benthos/v4/internal/bundle"
 	"github.com/redpanda-data/benthos/v4/internal/cli"
 	"github.com/redpanda-data/benthos/v4/internal/cli/common"
 	"github.com/redpanda-data/benthos/v4/internal/docs"
 	"github.com/redpanda-data/benthos/v4/internal/log"
-	ucli "github.com/urfave/cli/v2"
 )
 
 // RunCLI executes Benthos as a CLI, allowing users to specify a configuration

--- a/public/service/service.go
+++ b/public/service/service.go
@@ -13,6 +13,7 @@ import (
 	"github.com/redpanda-data/benthos/v4/internal/cli/common"
 	"github.com/redpanda-data/benthos/v4/internal/docs"
 	"github.com/redpanda-data/benthos/v4/internal/log"
+	ucli "github.com/urfave/cli/v2"
 )
 
 // RunCLI executes Benthos as a CLI, allowing users to specify a configuration
@@ -227,5 +228,14 @@ func CLIOptOnStreamStart(fn func(s *RunningStreamSummary) error) CLIOptFunc {
 		c.opts.OnStreamInit = func(s common.RunningStream) error {
 			return fn(&RunningStreamSummary{c: s})
 		}
+	}
+}
+
+// CLIOptCustomRunFlags sets a slice of custom cli flags and a closure to be
+// called once those flags are parsed.
+func CLIOptCustomRunFlags(flags []ucli.Flag, fn func(*ucli.Context) error) CLIOptFunc {
+	return func(c *CLIOptBuilder) {
+		c.opts.CustomRunFlags = flags
+		c.opts.CustomRunExtractFn = fn
 	}
 }

--- a/public/service/service_test.go
+++ b/public/service/service_test.go
@@ -122,5 +122,5 @@ output:
 			return nil
 		}))
 
-	assert.Equal(t, flagExtracted, "foobar")
+	assert.Equal(t, "foobar", flagExtracted)
 }

--- a/public/service/service_test.go
+++ b/public/service/service_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	"github.com/urfave/cli/v2"
 
 	_ "github.com/redpanda-data/benthos/v4/public/components/io"
 	_ "github.com/redpanda-data/benthos/v4/public/components/pure"
@@ -89,4 +90,37 @@ output:
 		"inputa":  true,
 		"outputa": true,
 	}, statusMap)
+}
+
+func TestRunCLICustomFlags(t *testing.T) {
+	tmpDir := t.TempDir()
+	confPath := filepath.Join(tmpDir, "foo.yaml")
+
+	require.NoError(t, os.WriteFile(confPath, []byte(`
+input:
+  label: inputa
+  generate:
+    count: 1
+    mapping: 'root.id = "foobar"'
+    interval: "1ms"
+
+output:
+  label: outputa
+  drop: {}
+`), 0o644))
+
+	var flagExtracted string
+	service.RunCLI(context.Background(),
+		service.CLIOptSetArgs("meow", "run", "--meow", "foobar", confPath),
+		service.CLIOptCustomRunFlags([]cli.Flag{
+			&cli.StringFlag{
+				Name:  "meow",
+				Value: "",
+			},
+		}, func(c *cli.Context) error {
+			flagExtracted = c.String("meow")
+			return nil
+		}))
+
+	assert.Equal(t, flagExtracted, "foobar")
 }


### PR DESCRIPTION
In order to allow custom flags when running configs I've had to add an opt func in the public service package that passes `github.com/urfave/cli/v2` types through. This isn't ideal as it locks us into using this CLI library long term in order to preserve backwards compatibility. However, that was likely the case anyway.

The long term plan is to expose enough functionality in the public packages that library users can actually build their own CLIs and we can remove the cli package from benthos.