### PR TITLE
Allow set flags to use negative array indexes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ All notable changes to this project will be documented in this file.
 - Field `follow_redirects` added to the `http` processor. (@ooesili)
 - Go API: Cli opt function added for custom CLI flags. (@Jeffail)
 
+### Changed
+
+- CLI `--set` flags can now mutate array values indexed from the end via negative integers. E.g. `--set 'foo.-1=meow'` would set the last index of the array `foo` to the value of `meow`.
+
 ## 4.39.0 - 2024-10-14
 
 ### Added

--- a/internal/docs/format_yaml_path.go
+++ b/internal/docs/format_yaml_path.go
@@ -72,6 +72,12 @@ func getIndexFromSequence(name string, allowAppend bool, node *yaml.Node) (*yaml
 		if err != nil {
 			return nil, fmt.Errorf("%v: failed to parse path segment as array index: %w", name, err)
 		}
+
+		// Allow negative indexes, which target from the end of the array.
+		if index < 0 {
+			index = len(node.Content) + index
+		}
+
 		if len(node.Content) <= index {
 			return nil, fmt.Errorf("%v: target index greater than array length", name)
 		}

--- a/internal/docs/format_yaml_path.go
+++ b/internal/docs/format_yaml_path.go
@@ -77,6 +77,9 @@ func getIndexFromSequence(name string, allowAppend bool, node *yaml.Node) (*yaml
 		if index < 0 {
 			index = len(node.Content) + index
 		}
+		if index < 0 {
+			return nil, fmt.Errorf("%v: target index less than zero", name)
+		}
 
 		if len(node.Content) <= index {
 			return nil, fmt.Errorf("%v: target index greater than array length", name)

--- a/internal/docs/format_yaml_path_test.go
+++ b/internal/docs/format_yaml_path_test.go
@@ -221,6 +221,23 @@ input:
 `,
 		},
 		{
+			name: "set array from end",
+			input: `
+input:
+  kafka:
+    addresses: [ "foo", "bar" ]
+    topics: [ "baz" ]
+`,
+			path:  "/input/kafka/addresses/-1",
+			value: `"baz"`,
+			output: `
+input:
+  kafka:
+    addresses: [ "foo", "baz" ]
+    topics: [ "baz" ]
+`,
+		},
+		{
 			name: "set array NaN",
 			input: `
 input:


### PR DESCRIPTION
This is going to useful on cloud, where we'd like to append and mutate SASL fields onto a users existing config.