### PR TITLE
perf: add checks for the internal data held by a message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 
 - Field `follow_redirects` added to the `http` processor. (@ooesili)
 - Go API: Cli opt function added for custom CLI flags. (@Jeffail)
+- Go API: Methods `HasStructured` and `HasBytes` added to the message type. (@rockwotj)
 
 ## 4.39.0 - 2024-10-14
 

--- a/internal/message/data.go
+++ b/internal/message/data.go
@@ -34,6 +34,14 @@ func (m *messageData) AsBytes() []byte {
 	return m.rawBytes
 }
 
+func (m *messageData) HasBytes() bool {
+	return m.rawBytes != nil
+}
+
+func (m *messageData) HasStructured() bool {
+	return m.structured != nil
+}
+
 func (m *messageData) SetStructured(jObj any) {
 	m.rawBytes = nil
 	if jObj == nil {

--- a/internal/message/part.go
+++ b/internal/message/part.go
@@ -82,6 +82,16 @@ func (p *Part) AsBytes() []byte {
 	return p.data.AsBytes()
 }
 
+// HasBytes returns true if the raw message bytes are readily available and cached.
+func (p *Part) HasBytes() bool {
+	return p.data.HasBytes()
+}
+
+// HasStructured returns true if the structured message data is readily available and cached.
+func (p *Part) HasStructured() bool {
+	return p.data.HasStructured()
+}
+
 // AsStructuredMut returns the structured format of the message if already set,
 // or attempts to parse the raw bytes as a JSON document if not. The returned
 // structure is mutable and therefore safe to mutate directly.

--- a/public/service/message.go
+++ b/public/service/message.go
@@ -236,6 +236,17 @@ func (m *Message) SetBytes(b []byte) {
 	m.part.SetBytes(b)
 }
 
+// HasBytes returns true if the raw message bytes are readily available and cached.
+func (m *Message) HasBytes() bool {
+	return m.part.HasBytes()
+}
+
+// HasStructured returns true if the structured message data is readily available
+// and cached.
+func (m *Message) HasStructured() bool {
+	return m.part.HasStructured()
+}
+
 // SetStructured sets the underlying contents of the message as a structured
 // type. This structured value should be a scalar Go type, or either a
 // map[string]interface{} or []interface{} containing the same types all the way


### PR DESCRIPTION
There might be optimizations to be done if the internal data is held as
bytes already (like reusing containers to save allocs when parsing lots of data).
