### PR TITLE
Fix wasm build by stubbing noReread().

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ All notable changes to this project will be documented in this file.
 - Go API: Cli opt function added for custom CLI flags. (@Jeffail)
 - Go API: Methods `HasStructured` and `HasBytes` added to the message type. (@rockwotj)
 
+### Fixed
+
+- WASM builds work again. (@voutilad)
+
 ### Changed
 
 - CLI `--set` flags can now mutate array values indexed from the end via negative integers. E.g. `--set 'foo.-1=meow'` would set the last index of the array `foo` to the value of `meow`.

--- a/internal/config/watcher_wasm.go
+++ b/internal/config/watcher_wasm.go
@@ -12,3 +12,8 @@ import (
 func (r *Reader) BeginFileWatching(mgr bundle.NewManagement, strict bool) error {
 	return errors.New("file watching is disabled in WASM builds")
 }
+
+// noReread is a no-op in WASM builds as the file watcher is not supported.
+func noReread(err error) error {
+	return err
+}


### PR DESCRIPTION
The file watcher doesn't apply to wasm builds, so make a no-op.

This fixes builds like:

```
GOOS=js GOARCH=wasm go build -o benthos.wasm ./cmd/benthos
```