### PR TITLE
feat: allowed the caller to specify timeout for stream api

### DIFF
--- a/internal/stream/manager/api.go
+++ b/internal/stream/manager/api.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/Jeffail/gabs/v2"
 	"github.com/gorilla/mux"
@@ -358,6 +359,17 @@ func (m *Type) HandleStreamCRUD(w http.ResponseWriter, r *http.Request) {
 
 	var conf stream.Config
 	var lints []string
+
+	ctx := r.Context()
+	if timeout := r.URL.Query().Get("timeout"); timeout != "" {
+		d, err := time.ParseDuration(timeout)
+		if err == nil { // ignore bad timeout query
+			var cancel context.CancelFunc
+			ctx, cancel = context.WithTimeout(ctx, d)
+			defer cancel()
+		}
+	}
+
 	switch r.Method {
 	case "POST":
 		if conf, lints, requestErr = readConfig(); requestErr != nil {
@@ -410,16 +422,16 @@ func (m *Type) HandleStreamCRUD(w http.ResponseWriter, r *http.Request) {
 			_, _ = w.Write(errBytes)
 			return
 		}
-		serverErr = m.Update(r.Context(), id, conf)
+		serverErr = m.Update(ctx, id, conf)
 	case "DELETE":
-		serverErr = m.Delete(r.Context(), id)
+		serverErr = m.Delete(ctx, id)
 	case "PATCH":
 		var info *StreamStatus
 		if info, serverErr = m.Read(id); serverErr == nil {
 			if conf, requestErr = patchConfig(info.Config()); requestErr != nil {
 				return
 			}
-			serverErr = m.Update(r.Context(), id, conf)
+			serverErr = m.Update(ctx, id, conf)
 		}
 	default:
 		requestErr = fmt.Errorf("verb not supported: %v", r.Method)

--- a/internal/stream/manager/type.go
+++ b/internal/stream/manager/type.go
@@ -227,7 +227,9 @@ func (m *Type) Delete(ctx context.Context, id string) error {
 	}
 
 	if err := wrapper.strm.Stop(ctx); err != nil {
-		return err
+		if !(errors.Is(err, context.DeadlineExceeded) || errors.Is(err, context.Canceled)) {
+			return err
+		}
 	}
 
 	m.lock.Lock()

--- a/internal/stream/type.go
+++ b/internal/stream/type.go
@@ -290,7 +290,7 @@ func (t *Type) Stop(ctx context.Context) error {
 	if err == nil {
 		return nil
 	}
-	if !(errors.Is(err, context.Canceled) && errors.Is(err, context.DeadlineExceeded)) {
+	if !(errors.Is(err, context.Canceled) || errors.Is(err, context.DeadlineExceeded)) {
 		t.manager.Logger().Error("Encountered error whilst attempting to shut down gracefully: %v\n", err)
 	}
 


### PR DESCRIPTION
We use benthos/redpanda-connect as the pipeline service. Often the users don't really care about the at-least-once semantics too much and they just want the pipeline to be deleted/updated ASAP. 

This PR enhanced the stream API to support the `timeout` query parameter to achieve the goal
