### PR TITLE
use provided context for batched writer closing

### DIFF
--- a/public/service/output.go
+++ b/public/service/output.go
@@ -118,7 +118,7 @@ func (a *airGapBatchWriter) WriteBatch(ctx context.Context, msg message.Batch) e
 }
 
 func (a *airGapBatchWriter) Close(ctx context.Context) error {
-	return a.w.Close(context.Background())
+	return a.w.Close(ctx)
 }
 
 //------------------------------------------------------------------------------


### PR DESCRIPTION
Something I noticed when reading the code
