### PR TITLE
feat(benchmark): add benchmark processor

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/Jeffail/shutdown v1.0.0
 	github.com/OneOfOne/xxhash v1.2.8
 	github.com/cenkalti/backoff/v4 v4.3.0
+	github.com/dustin/go-humanize v1.0.1
 	github.com/fatih/color v1.17.0
 	github.com/fsnotify/fsnotify v1.7.0
 	github.com/gofrs/uuid v4.4.0+incompatible
@@ -52,7 +53,6 @@ require (
 	github.com/cockroachdb/apd/v3 v3.2.1 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.4 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
-	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/go-logr/logr v1.4.2 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect

--- a/go.mod
+++ b/go.mod
@@ -52,6 +52,7 @@ require (
 	github.com/cockroachdb/apd/v3 v3.2.1 // indirect
 	github.com/cpuguy83/go-md2man/v2 v2.0.4 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/dustin/go-humanize v1.0.1 // indirect
 	github.com/felixge/httpsnoop v1.0.4 // indirect
 	github.com/go-logr/logr v1.4.2 // indirect
 	github.com/go-logr/stdr v1.2.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -19,6 +19,8 @@ github.com/cpuguy83/go-md2man/v2 v2.0.4/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46t
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/dustin/go-humanize v1.0.1 h1:GzkhY7T5VNhEkwH0PVJgjz+fX1rhBrR7pRT3mDkpeCY=
+github.com/dustin/go-humanize v1.0.1/go.mod h1:Mu1zIs6XwVuF/gI1OepvI0qD18qycQx+mFykh5fBlto=
 github.com/emicklei/proto v1.10.0 h1:pDGyFRVV5RvV+nkBK9iy3q67FBy9Xa7vwrOTE+g5aGw=
 github.com/emicklei/proto v1.10.0/go.mod h1:rn1FgRS/FANiZdD2djyH7TMA9jdRDcYQ9IEN9yvjX0A=
 github.com/fatih/color v1.17.0 h1:GlRw1BRJxkpqUCBKzKOw098ed57fEsKeNjpTe3cSjK4=

--- a/internal/impl/pure/processor_benchmark.go
+++ b/internal/impl/pure/processor_benchmark.go
@@ -19,7 +19,8 @@ func init() {
 }
 
 const (
-	bmFieldInterval = "interval"
+	bmFieldInterval   = "interval"
+	bmFieldCountBytes = "count_bytes"
 )
 
 func benchmarkSpec() *service.ConfigSpec {
@@ -29,8 +30,11 @@ func benchmarkSpec() *service.ConfigSpec {
 		Description("Logs messages per second and bytes per second of messages that are processed at a regular interval. A summary of the amount of messages processed over the entire lifetime of the processor will also be printed when the processor shuts down.").
 		Field(service.NewDurationField(bmFieldInterval).
 			Description("How often to emit rolling statistics. If set to 0, only a summary will be logged when the processor shuts down.").
-			Default("5s").
-			Description("How often to emit rolling statistics."),
+			Default("5s"),
+		).
+		Field(service.NewBoolField(bmFieldCountBytes).
+			Description("Whether or not to measure the number of bytes per second of throughput. Counting the number of bytes requires serializing structured data, which can cause an unnecessary performance hit if serialization is not required elsewhere in the pipeline.").
+			Default(true),
 		)
 }
 
@@ -39,10 +43,15 @@ func newBenchmarkProcFromConfig(conf *service.ParsedConfig, mgr *service.Resourc
 	if err != nil {
 		return nil, err
 	}
+	countBytes, err := conf.FieldBool(bmFieldCountBytes)
+	if err != nil {
+		return nil, err
+	}
 
 	b := &benchmarkProc{
 		startTime:       time.Now(),
 		rollingInterval: interval,
+		countBytes:      countBytes,
 		logger:          mgr.Logger(),
 	}
 
@@ -60,6 +69,7 @@ func newBenchmarkProcFromConfig(conf *service.ParsedConfig, mgr *service.Resourc
 type benchmarkProc struct {
 	startTime       time.Time
 	rollingInterval time.Duration
+	countBytes      bool
 	logger          *service.Logger
 
 	lock         sync.Mutex
@@ -71,16 +81,22 @@ type benchmarkProc struct {
 }
 
 func (b *benchmarkProc) Process(ctx context.Context, msg *service.Message) (service.MessageBatch, error) {
-	bytes, err := msg.AsBytes()
-	if err != nil {
-		return nil, fmt.Errorf("getting message bytes: %w", err)
+	var bytesCount float64
+	if b.countBytes {
+		bytes, err := msg.AsBytes()
+		if err != nil {
+			return nil, fmt.Errorf("getting message bytes: %w", err)
+		}
+		bytesCount = float64(len(bytes))
 	}
 
-	bytesCount := float64(len(bytes))
-
 	b.lock.Lock()
-	b.rollingStats.recordMessage(bytesCount)
-	b.totalStats.recordMessage(bytesCount)
+	b.rollingStats.msgCount++
+	b.totalStats.msgCount++
+	if b.countBytes {
+		b.rollingStats.msgBytesCount += bytesCount
+		b.totalStats.msgBytesCount += bytesCount
+	}
 	b.lock.Unlock()
 
 	return service.MessageBatch{msg}, nil
@@ -116,27 +132,32 @@ func (b *benchmarkProc) sampleRolling() benchmarkStats {
 func (b *benchmarkProc) printStats(window string, stats benchmarkStats, interval time.Duration) {
 	secs := interval.Seconds()
 	msgsPerSec := stats.msgCount / secs
-	bytesPerSec := stats.msgBytesCount / secs
-	b.logger.
-		With(
-			"msg/sec", msgsPerSec,
-			"bytes/sec", bytesPerSec,
-		).
-		Infof(
-			"%s stats: %s msg/sec, %s/sec",
-			window,
-			humanize.Ftoa(msgsPerSec),
-			humanize.Bytes(uint64(bytesPerSec)),
-		)
+
+	if b.countBytes {
+		bytesPerSec := stats.msgBytesCount / secs
+		b.logger.
+			With(
+				"msg/sec", msgsPerSec,
+				"bytes/sec", bytesPerSec,
+			).
+			Infof(
+				"%s stats: %s msg/sec, %s/sec",
+				window,
+				humanize.Ftoa(msgsPerSec),
+				humanize.Bytes(uint64(bytesPerSec)),
+			)
+	} else {
+		b.logger.
+			With("msg/sec", msgsPerSec).
+			Infof(
+				"%s stats: %s msg/sec",
+				window,
+				humanize.Ftoa(msgsPerSec),
+			)
+	}
 }
 
 type benchmarkStats struct {
 	msgCount      float64
 	msgBytesCount float64
-}
-
-func (s *benchmarkStats) recordMessage(bytesCount float64) {
-	s.msgCount++
-	s.msgCount++
-	s.msgBytesCount += float64(bytesCount)
 }

--- a/internal/impl/pure/processor_benchmark.go
+++ b/internal/impl/pure/processor_benchmark.go
@@ -19,6 +19,7 @@ import (
 	"sync"
 	"time"
 
+	"github.com/dustin/go-humanize"
 	"github.com/redpanda-data/benthos/v4/public/service"
 )
 
@@ -133,13 +134,13 @@ func (b *benchmarkProc) sampleRolling() benchmarkStats {
 	return s
 }
 
-func (b *benchmarkProc) printStats(window string, s benchmarkStats, interval time.Duration) {
+func (b *benchmarkProc) printStats(window string, stats benchmarkStats, interval time.Duration) {
 	secs := interval.Seconds()
 	b.logger.Infof(
-		"%s stats: %.2f msgs/sec, %.2f bytes/sec",
+		"%s stats: %s msg/sec, %s/sec",
 		window,
-		s.msgCount/secs,
-		s.msgBytesCount/secs,
+		humanize.Ftoa(stats.msgCount/secs),
+		humanize.Bytes(uint64(stats.msgBytesCount/secs)),
 	)
 }
 

--- a/internal/impl/pure/processor_benchmark.go
+++ b/internal/impl/pure/processor_benchmark.go
@@ -26,7 +26,7 @@ const (
 func benchmarkSpec() *service.ConfigSpec {
 	return service.NewConfigSpec().
 		Categories("Utility").
-		Summary("Logs basic throughput statistics of message that pass through this processor.").
+		Summary("Logs basic throughput statistics of messages that pass through this processor.").
 		Description("Logs messages per second and bytes per second of messages that are processed at a regular interval. A summary of the amount of messages processed over the entire lifetime of the processor will also be printed when the processor shuts down.").
 		Field(service.NewDurationField(bmFieldInterval).
 			Description("How often to emit rolling statistics. If set to 0, only a summary will be logged when the processor shuts down.").

--- a/internal/impl/pure/processor_benchmark.go
+++ b/internal/impl/pure/processor_benchmark.go
@@ -54,17 +54,16 @@ func newBenchmarkProcFromConfig(conf *service.ParsedConfig, reporter benchmarkRe
 	}
 
 	b := &benchmarkProc{
-		startTime:       now(),
-		rollingInterval: interval,
-		countBytes:      countBytes,
-		reporter:        reporter,
-		now:             now,
+		startTime:  now(),
+		countBytes: countBytes,
+		reporter:   reporter,
+		now:        now,
 	}
 
 	if interval.String() != "0s" {
 		b.periodic = periodic.New(interval, func() {
 			stats := b.sampleRolling()
-			b.printStats("rolling", stats, b.rollingInterval)
+			b.printStats("rolling", stats, interval)
 		})
 		b.periodic.Start()
 	}
@@ -73,10 +72,9 @@ func newBenchmarkProcFromConfig(conf *service.ParsedConfig, reporter benchmarkRe
 }
 
 type benchmarkProc struct {
-	startTime       time.Time
-	rollingInterval time.Duration
-	countBytes      bool
-	reporter        benchmarkReporter
+	startTime  time.Time
+	countBytes bool
+	reporter   benchmarkReporter
 
 	lock         sync.Mutex
 	rollingStats benchmarkStats

--- a/internal/impl/pure/processor_benchmark.go
+++ b/internal/impl/pure/processor_benchmark.go
@@ -1,0 +1,155 @@
+// Copyright 2024 Redpanda Data, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//	http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+package pure
+
+import (
+	"context"
+	"fmt"
+	"sync"
+	"time"
+
+	"github.com/redpanda-data/benthos/v4/public/service"
+)
+
+func init() {
+	err := service.RegisterProcessor("benchmark", benchmarkSpec(), newBenchmarkProcFromConfig)
+	if err != nil {
+		panic(err)
+	}
+}
+
+const (
+	bmFieldInterval = "interval"
+)
+
+func benchmarkSpec() *service.ConfigSpec {
+	return service.NewConfigSpec().
+		Categories("Utility").
+		Summary("Logs basic throughput statistics of message that pass through this processor.").
+		Description("Logs messages per second and bytes per second of messages that are processed at a regular interval. A summary of the amount of messages processed over the entire lifetime of the processor will also be printed when the processor shuts down.").
+		Field(service.NewDurationField(bmFieldInterval).
+			Description("How often to emit rolling statistics. If set to 0, only a summary will be logged when the processor shuts down.").
+			Default("5s").
+			Description("How often to emit rolling statistics."),
+		)
+}
+
+func newBenchmarkProcFromConfig(conf *service.ParsedConfig, mgr *service.Resources) (service.Processor, error) {
+	interval, err := conf.FieldDuration(bmFieldInterval)
+	if err != nil {
+		return nil, err
+	}
+
+	done := make(chan struct{})
+	b := &benchmarkProc{
+		startTime:       time.Now(),
+		rollingInterval: interval,
+		logger:          mgr.Logger(),
+		done:            done,
+	}
+
+	if interval.String() != "0s" {
+		go func() {
+			ticker := time.NewTicker(interval)
+			defer ticker.Stop()
+			defer b.wg.Done()
+
+			for {
+				select {
+				case <-done:
+					break
+
+				case <-ticker.C:
+					stats := b.sampleRolling()
+					b.printStats("rolling", stats, b.rollingInterval)
+				}
+			}
+		}()
+	}
+
+	return b, nil
+}
+
+type benchmarkProc struct {
+	startTime       time.Time
+	rollingInterval time.Duration
+	logger          *service.Logger
+
+	lock         sync.Mutex
+	rollingStats benchmarkStats
+	totalStats   benchmarkStats
+
+	wg   sync.WaitGroup
+	done chan<- struct{}
+}
+
+func (b *benchmarkProc) Process(ctx context.Context, msg *service.Message) (service.MessageBatch, error) {
+	bytes, err := msg.AsBytes()
+	if err != nil {
+		return nil, fmt.Errorf("getting message bytes: %w", err)
+	}
+
+	bytesCount := float64(len(bytes))
+
+	b.lock.Lock()
+	b.rollingStats.recordMessage(bytesCount)
+	b.totalStats.recordMessage(bytesCount)
+	b.lock.Unlock()
+
+	return service.MessageBatch{msg}, nil
+}
+
+func (b *benchmarkProc) Close(ctx context.Context) error {
+	if b.done == nil {
+		return nil
+	}
+
+	close(b.done)
+	b.wg.Wait()
+	b.done = nil
+
+	b.printStats("total", b.totalStats, time.Since(b.startTime))
+	return nil
+}
+
+func (b *benchmarkProc) sampleRolling() benchmarkStats {
+	b.lock.Lock()
+	defer b.lock.Unlock()
+
+	s := b.rollingStats
+	b.rollingStats.msgCount = 0
+	b.rollingStats.msgBytesCount = 0
+	return s
+}
+
+func (b *benchmarkProc) printStats(window string, s benchmarkStats, interval time.Duration) {
+	secs := interval.Seconds()
+	b.logger.Infof(
+		"%s stats: %.2f msgs/sec, %.2f bytes/sec",
+		window,
+		s.msgCount/secs,
+		s.msgBytesCount/secs,
+	)
+}
+
+type benchmarkStats struct {
+	msgCount      float64
+	msgBytesCount float64
+}
+
+func (s *benchmarkStats) recordMessage(bytesCount float64) {
+	s.msgCount++
+	s.msgCount++
+	s.msgBytesCount += float64(bytesCount)
+}

--- a/internal/impl/pure/processor_benchmark.go
+++ b/internal/impl/pure/processor_benchmark.go
@@ -1,16 +1,3 @@
-// Copyright 2024 Redpanda Data, Inc.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//	http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
 package pure
 
 import (

--- a/internal/impl/pure/processor_benchmark_test.go
+++ b/internal/impl/pure/processor_benchmark_test.go
@@ -1,0 +1,101 @@
+package pure
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/redpanda-data/benthos/v4/public/service"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBenchmarkProcessor(t *testing.T) {
+	conf, err := benchmarkSpec().ParseYAML(`
+interval: 0
+`, nil)
+	require.NoError(t, err)
+
+	currentTime := time.Now()
+	now := func() time.Time { return currentTime }
+	reporter := &mockBenchmarkReporter{}
+
+	benchmarkProc, err := newBenchmarkProcFromConfig(conf, reporter, now)
+	require.NoError(t, err)
+
+	msg := service.NewMessage([]byte("hello"))
+	for i := 0; i < 5; i++ {
+		batch, err := benchmarkProc.Process(context.Background(), msg)
+		require.NoError(t, err)
+		require.Equal(t, service.MessageBatch{msg}, batch)
+	}
+
+	currentTime = currentTime.Add(time.Second)
+	benchmarkProc.Close(context.Background())
+
+	require.Equal(t, []mockBenchmarkReport{
+		{
+			window:      "total",
+			msgsPerSec:  5,
+			bytesPerSec: 25,
+		},
+	}, reporter.reports)
+}
+
+func TestBenchmarkProcessorNoBytes(t *testing.T) {
+	conf, err := benchmarkSpec().ParseYAML(`
+interval: 0
+count_bytes: false
+`, nil)
+	require.NoError(t, err)
+
+	currentTime := time.Now()
+	now := func() time.Time { return currentTime }
+	reporter := &mockBenchmarkReporter{}
+
+	benchmarkProc, err := newBenchmarkProcFromConfig(conf, reporter, now)
+	require.NoError(t, err)
+
+	msg := service.NewMessage([]byte("hello"))
+	for i := 0; i < 5; i++ {
+		batch, err := benchmarkProc.Process(context.Background(), msg)
+		require.NoError(t, err)
+		require.Equal(t, service.MessageBatch{msg}, batch)
+	}
+
+	currentTime = currentTime.Add(time.Second)
+	benchmarkProc.Close(context.Background())
+
+	require.Equal(t, []mockBenchmarkReport{
+		{
+			window:      "total",
+			msgsPerSec:  5,
+			bytesPerSec: -1,
+		},
+	}, reporter.reports)
+}
+
+type mockBenchmarkReporter struct {
+	reports []mockBenchmarkReport
+}
+
+type mockBenchmarkReport struct {
+	window      string
+	msgsPerSec  float64
+	bytesPerSec float64
+}
+
+func (l *mockBenchmarkReporter) reportStats(window string, msgsPerSec, bytesPerSec float64) {
+	l.reports = append(l.reports, mockBenchmarkReport{
+		window:      window,
+		msgsPerSec:  msgsPerSec,
+		bytesPerSec: bytesPerSec,
+	})
+}
+
+func (l *mockBenchmarkReporter) reportStatsNoBytes(window string, msgsPerSec float64) {
+	l.reports = append(l.reports, mockBenchmarkReport{
+		window:      window,
+		msgsPerSec:  msgsPerSec,
+		bytesPerSec: -1,
+	})
+}

--- a/internal/periodic/periodic.go
+++ b/internal/periodic/periodic.go
@@ -1,0 +1,80 @@
+package periodic
+
+import (
+	"context"
+	"time"
+)
+
+// Periodic holds a background goroutine that can do periodic work.
+//
+// The work here cannot communicate errors directly, so it must
+// communicate with channels or swallow errors.
+//
+// NOTE: It's expected that Start and Stop are called on the same
+// goroutine or be externally synchronized as to not race.
+type Periodic struct {
+	duration time.Duration
+	work     func(context.Context)
+
+	cancel context.CancelFunc
+	done   chan any
+}
+
+// New creates new background work that runs every `duration` and performs `work`.
+func New(duration time.Duration, work func()) *Periodic {
+	return &Periodic{
+		duration: duration,
+		work:     func(context.Context) { work() },
+	}
+}
+
+// NewWithContext creates new background work that runs every `duration` and performs `work`.
+//
+// Work is passed a context that is cancelled when the overall periodic is cancelled.
+func NewWithContext(duration time.Duration, work func(context.Context)) *Periodic {
+	return &Periodic{
+		duration: duration,
+		work:     work,
+	}
+}
+
+// Start starts the `Periodic` work.
+//
+// It does not do work immedately, only after the time has passed.
+func (p *Periodic) Start() {
+	if p.cancel != nil {
+		return
+	}
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan any)
+	go runBackgroundLoop(ctx, p.duration, done, p.work)
+	p.cancel = cancel
+	p.done = done
+}
+
+func runBackgroundLoop(ctx context.Context, d time.Duration, done chan any, work func(context.Context)) {
+	refreshTimer := time.NewTicker(d)
+	defer func() {
+		refreshTimer.Stop()
+		close(done)
+	}()
+	for ctx.Err() == nil {
+		select {
+		case <-refreshTimer.C:
+			work(ctx)
+		case <-ctx.Done():
+			return
+		}
+	}
+}
+
+// Stop stops the periodic work and waits for the background goroutine to exit.
+func (p *Periodic) Stop() {
+	if p.cancel == nil {
+		return
+	}
+	p.cancel()
+	<-p.done
+	p.done = nil
+	p.cancel = nil
+}

--- a/internal/periodic/periodic_test.go
+++ b/internal/periodic/periodic_test.go
@@ -1,0 +1,48 @@
+package periodic
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestCancellation(t *testing.T) {
+	counter := atomic.Int32{}
+	p := New(time.Hour, func() {
+		counter.Add(1)
+	})
+	p.Start()
+	require.Equal(t, int32(0), counter.Load())
+	p.Stop()
+	require.Equal(t, int32(0), counter.Load())
+}
+
+func TestWorks(t *testing.T) {
+	counter := atomic.Int32{}
+	p := New(time.Millisecond, func() {
+		counter.Add(1)
+	})
+	p.Start()
+	require.Eventually(t, func() bool { return counter.Load() > 5 }, time.Second, time.Millisecond)
+	p.Stop()
+	snapshot := counter.Load()
+	time.Sleep(time.Millisecond * 250)
+	require.Equal(t, snapshot, counter.Load())
+}
+
+func TestWorksWithContext(t *testing.T) {
+	active := atomic.Bool{}
+	p := NewWithContext(time.Millisecond, func(ctx context.Context) {
+		active.Store(true)
+		// Block until context is cancelled
+		<-ctx.Done()
+		active.Store(false)
+	})
+	p.Start()
+	require.Eventually(t, func() bool { return active.Load() }, 10*time.Millisecond, time.Millisecond)
+	p.Stop()
+	require.False(t, active.Load())
+}


### PR DESCRIPTION
This processor emits rough throughput metrics which is useful for ad-hoc speed measurements of different combinations of input and output plugins.