### PR TITLE
Always add run flags even for hidden commands

### DIFF
--- a/internal/cli/common/run_flags.go
+++ b/internal/cli/common/run_flags.go
@@ -138,11 +138,6 @@ func RunFlags(opts *CLIOpts, hidden bool) []cli.Flag {
 			Usage:   "EXPERIMENTAL: watch config files for changes and automatically apply them",
 		},
 	}
-	if hidden {
-		return f
-	}
-
-	// Only add custom flags when not hidden
 	return append(f, opts.CustomRunFlags...)
 }
 


### PR DESCRIPTION
Having the custom run flags skipped for hidden commands kind of made sense because it means we avoid adding new behaviour to old stuff. However, in connect this also prevents the default secrets flags from being applied when running with the deprecated `-c` flag, which breaks backwards compatibility.