### PR TITLE
Fix template usage with custom environments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ Changelog
 
 All notable changes to this project will be documented in this file.
 
+## 4.41.1 - 2024-11-25
+
+### Fixed
+
+- Fixed an issue where running a CLI with a custom environment would cause imported templates to be rejected.
+
 ## 4.41.0 - 2024-11-20
 
 ### Added

--- a/internal/cli/common/reader.go
+++ b/internal/cli/common/reader.go
@@ -2,6 +2,7 @@ package common
 
 import (
 	"github.com/redpanda-data/benthos/v4/internal/config"
+	"github.com/redpanda-data/benthos/v4/internal/docs"
 	"github.com/redpanda-data/benthos/v4/internal/filepath/ifs"
 
 	"github.com/urfave/cli/v2"
@@ -22,10 +23,14 @@ func ReadConfig(c *cli.Context, cliOpts *CLIOpts, streamsMode bool) (mainPath st
 			}
 		}
 	}
+
+	lintConf := docs.NewLintConfig(cliOpts.Environment)
+
 	opts := []config.OptFunc{
 		config.OptSetFullSpec(cliOpts.MainConfigSpecCtor),
 		config.OptAddOverrides(cliOpts.RootFlags.GetSet(c)...),
 		config.OptTestSuffix("_benthos_test"),
+		config.OptSetLintConfig(lintConf),
 	}
 	if streamsMode {
 		opts = append(opts, config.OptSetStreamPaths(c.Args().Slice()...))

--- a/internal/cli/common/run_flags.go
+++ b/internal/cli/common/run_flags.go
@@ -189,7 +189,7 @@ func PreApplyEnvFilesAndTemplates(c *cli.Context, opts *CLIOpts) error {
 	if err != nil {
 		return fmt.Errorf("failed to resolve template glob pattern: %w", err)
 	}
-	lints, err := template.InitTemplates(templatesPaths...)
+	lints, err := template.InitTemplates(opts.Environment, opts.BloblEnvironment, templatesPaths...)
 	if err != nil {
 		return fmt.Errorf("template file read error: %w", err)
 	}

--- a/internal/cli/template/lint.go
+++ b/internal/cli/template/lint.go
@@ -7,6 +7,8 @@ import (
 	"github.com/fatih/color"
 	"github.com/urfave/cli/v2"
 
+	"github.com/redpanda-data/benthos/v4/internal/bloblang"
+	"github.com/redpanda-data/benthos/v4/internal/bundle"
 	"github.com/redpanda-data/benthos/v4/internal/cli/common"
 	"github.com/redpanda-data/benthos/v4/internal/docs"
 	ifilepath "github.com/redpanda-data/benthos/v4/internal/filepath"
@@ -74,7 +76,7 @@ type pathLint struct {
 }
 
 func lintFile(path string) (pathLints []pathLint) {
-	conf, lints, err := template.ReadConfigFile(path)
+	conf, lints, err := template.ReadConfigFile(bundle.GlobalEnvironment, path)
 	if err != nil {
 		pathLints = append(pathLints, pathLint{
 			source: path,
@@ -90,7 +92,7 @@ func lintFile(path string) (pathLints []pathLint) {
 		})
 	}
 
-	testErrors, err := conf.Test()
+	testErrors, err := conf.Test(bundle.GlobalEnvironment, bloblang.GlobalEnvironment())
 	if err != nil {
 		pathLints = append(pathLints, pathLint{
 			source: path,

--- a/internal/template/template_test.go
+++ b/internal/template/template_test.go
@@ -24,7 +24,7 @@ func TestCacheTemplate(t *testing.T) {
 	mgr, err := manager.New(manager.NewResourceConfig())
 	require.NoError(t, err)
 
-	require.NoError(t, template.RegisterTemplateYAML(mgr.Environment(), []byte(`
+	require.NoError(t, template.RegisterTemplateYAML(mgr.Environment(), mgr.BloblEnvironment(), []byte(`
 name: foo_memory
 type: cache
 
@@ -56,7 +56,7 @@ func TestInputTemplate(t *testing.T) {
 	mgr, err := manager.New(manager.NewResourceConfig())
 	require.NoError(t, err)
 
-	require.NoError(t, template.RegisterTemplateYAML(mgr.Environment(), []byte(`
+	require.NoError(t, template.RegisterTemplateYAML(mgr.Environment(), mgr.BloblEnvironment(), []byte(`
 name: generate_a_foo
 type: input
 
@@ -116,7 +116,7 @@ func TestOutputTemplate(t *testing.T) {
 	mgr, err := manager.New(manager.NewResourceConfig())
 	require.NoError(t, err)
 
-	require.NoError(t, template.RegisterTemplateYAML(mgr.Environment(), []byte(`
+	require.NoError(t, template.RegisterTemplateYAML(mgr.Environment(), mgr.BloblEnvironment(), []byte(`
 name: write_inproc
 type: output
 
@@ -190,7 +190,7 @@ func TestProcessorTemplate(t *testing.T) {
 	mgr, err := manager.New(manager.NewResourceConfig())
 	require.NoError(t, err)
 
-	require.NoError(t, template.RegisterTemplateYAML(mgr.Environment(), []byte(`
+	require.NoError(t, template.RegisterTemplateYAML(mgr.Environment(), mgr.BloblEnvironment(), []byte(`
 name: append_foo
 type: processor
 
@@ -225,7 +225,7 @@ func TestProcessorTemplateOddIndentation(t *testing.T) {
 	mgr, err := manager.New(manager.NewResourceConfig())
 	require.NoError(t, err)
 
-	require.NoError(t, template.RegisterTemplateYAML(mgr.Environment(), []byte(`
+	require.NoError(t, template.RegisterTemplateYAML(mgr.Environment(), mgr.BloblEnvironment(), []byte(`
 name: meow
 type: processor
 
@@ -267,7 +267,7 @@ func TestRateLimitTemplate(t *testing.T) {
 	mgr, err := manager.New(manager.NewResourceConfig())
 	require.NoError(t, err)
 
-	require.NoError(t, template.RegisterTemplateYAML(mgr.Environment(), []byte(`
+	require.NoError(t, template.RegisterTemplateYAML(mgr.Environment(), mgr.BloblEnvironment(), []byte(`
 name: foo
 type: rate_limit
 

--- a/public/service/environment.go
+++ b/public/service/environment.go
@@ -695,7 +695,7 @@ func (e *Environment) GetScannerConfig(name string) (*ConfigView, bool) {
 // document, to the environment such that it may be used similarly to any other
 // component plugin.
 func (e *Environment) RegisterTemplateYAML(yamlStr string) error {
-	return template.RegisterTemplateYAML(e.internal, []byte(yamlStr))
+	return template.RegisterTemplateYAML(e.internal, e.getBloblangParserEnv(), []byte(yamlStr))
 }
 
 // XFormatConfigJSON returns a byte slice of the Benthos configuration spec

--- a/public/service/stream_template_tester.go
+++ b/public/service/stream_template_tester.go
@@ -47,7 +47,7 @@ func (s *StreamTemplateTester) RunYAML(yamlBytes []byte) (lints []Lint, err erro
 		return
 	}
 
-	testErrors, err := conf.Test()
+	testErrors, err := conf.Test(s.env.internal, s.env.getBloblangParserEnv())
 	if err != nil {
 		lints = append(lints, Lint{Line: 1, Type: LintFailedRead, What: err.Error()})
 		return


### PR DESCRIPTION
Templates were being registered against a global environment, but custom CLIs are able to lock in a custom environment, in which case templates were skipped. I've fixed this as well as a few other locations where custom environments were being ignored.