### PR TITLE
Revise `branch` processor logging

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,11 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 - Field `label` added to the template tests definitions. (@mihaitodor)
-- Metadata field `label` can now be utilized within a template's `mapping` field to access the label that is associated with the template instantiation in a config.
+- Metadata field `label` can now be utilized within a template's `mapping` field to access the label that is associated with the template instantiation in a config. (@mihaitodor)
+
+### Changed
+
+- The `branch` processor no longer emits an entry in the log at error level when the child processors throw errors. (@mihaitodor)
 
 ## 4.42.0 - 2024-11-29
 

--- a/internal/impl/pure/processor_branch.go
+++ b/internal/impl/pure/processor_branch.go
@@ -352,7 +352,7 @@ func newBranchMapError(index int, err error) branchMapError {
 
 // createResult performs reduction and child processors to a payload. The size
 // of the payload will remain unchanged, where reduced indexes are nil. This
-// result can be overlayed onto the original message in order to complete the
+// result can be overlaid onto the original message in order to complete the
 // map.
 func (b *Branch) createResult(ctx context.Context, parts []*message.Part, referenceMsg message.Batch) ([]*message.Part, []branchMapError, error) {
 	originalLen := len(parts)

--- a/internal/impl/pure/processor_branch.go
+++ b/internal/impl/pure/processor_branch.go
@@ -318,7 +318,7 @@ func (b *Branch) ProcessBatch(ctx context.Context, batch message.Batch) ([]messa
 
 	for _, e := range mapErrs {
 		batch.Get(e.index).ErrorSet(e.err)
-		b.log.Error("Branch error: %v", e.err)
+		b.log.Debug("Branch error: %v", e.err)
 	}
 
 	if mapErrs, err = b.overlayResult(batch, resultParts); err != nil {

--- a/internal/impl/pure/processor_branch_test.go
+++ b/internal/impl/pure/processor_branch_test.go
@@ -300,11 +300,11 @@ branch:
 	require.NoError(t, res)
 	assert.Len(t, outMsgs, 1)
 
-	assert.Len(t, log.Debugs, 1)
+	assert.Len(t, log.Debugs, 2)
 	assert.Equal(t, "Processor failed: failed assignment (line 1): kaboom!", log.Debugs[0])
-	assert.Len(t, log.Errors, 2)
+	assert.Equal(t, "Branch error: processors failed: failed assignment (line 1): kaboom!", log.Debugs[1])
+	require.Len(t, log.Errors, 1)
 	assert.Equal(t, "failed assignment (line 1): kaboom!", log.Errors[0])
-	assert.Equal(t, "Branch error: processors failed: failed assignment (line 1): kaboom!", log.Errors[1])
 
 	ctx, done := context.WithTimeout(context.Background(), time.Second*1)
 	defer done()

--- a/internal/impl/pure/processor_branch_test.go
+++ b/internal/impl/pure/processor_branch_test.go
@@ -11,6 +11,7 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/redpanda-data/benthos/v4/internal/component/testutil"
+	log_testutil "github.com/redpanda-data/benthos/v4/internal/log/testutil"
 	"github.com/redpanda-data/benthos/v4/internal/manager/mock"
 	"github.com/redpanda-data/benthos/v4/internal/message"
 
@@ -272,4 +273,40 @@ branch:
 			assert.NoError(t, proc.Close(ctx))
 		})
 	}
+}
+
+func TestBranchLogging(t *testing.T) {
+	conf, err := testutil.ProcessorFromYAML(`
+branch:
+  processors:
+    - mapping: |
+        root = throw("kaboom!")
+`)
+	require.NoError(t, err)
+
+	log := log_testutil.MockLog{}
+	mgr := mock.NewManager()
+	mgr.L = &log
+
+	proc, err := mgr.NewProcessor(conf)
+	require.NoError(t, err)
+
+	msg := message.QuickBatch(nil)
+
+	part := message.NewPart([]byte(""))
+	msg = append(msg, part)
+
+	outMsgs, res := proc.ProcessBatch(context.Background(), msg.ShallowCopy())
+	require.NoError(t, res)
+	assert.Len(t, outMsgs, 1)
+
+	assert.Len(t, log.Debugs, 1)
+	assert.Equal(t, "Processor failed: failed assignment (line 1): kaboom!", log.Debugs[0])
+	assert.Len(t, log.Errors, 2)
+	assert.Equal(t, "failed assignment (line 1): kaboom!", log.Errors[0])
+	assert.Equal(t, "Branch error: processors failed: failed assignment (line 1): kaboom!", log.Errors[1])
+
+	ctx, done := context.WithTimeout(context.Background(), time.Second*1)
+	defer done()
+	assert.NoError(t, proc.Close(ctx))
 }

--- a/internal/impl/pure/processor_for_each.go
+++ b/internal/impl/pure/processor_for_each.go
@@ -3,7 +3,6 @@ package pure
 import (
 	"context"
 
-	"github.com/redpanda-data/benthos/v4/internal/bundle"
 	"github.com/redpanda-data/benthos/v4/internal/component/interop"
 	"github.com/redpanda-data/benthos/v4/internal/component/processor"
 	"github.com/redpanda-data/benthos/v4/internal/message"
@@ -32,7 +31,7 @@ Please note that most processors already process per message of a batch, and thi
 				childProcs[i] = interop.UnwrapOwnedProcessor(p)
 			}
 
-			tp, err := newForEach(childProcs, mgr)
+			tp, err := newForEach(childProcs)
 			if err != nil {
 				return nil, err
 			}
@@ -49,7 +48,7 @@ type forEachProc struct {
 	children []processor.V1
 }
 
-func newForEach(children []processor.V1, mgr bundle.NewManagement) (*forEachProc, error) {
+func newForEach(children []processor.V1) (*forEachProc, error) {
 	return &forEachProc{children: children}, nil
 }
 

--- a/internal/log/testutil/mock_log.go
+++ b/internal/log/testutil/mock_log.go
@@ -1,0 +1,86 @@
+package testutil
+
+import (
+	"fmt"
+
+	"github.com/redpanda-data/benthos/v4/internal/log"
+)
+
+// MockLog is a mock log.Modular implementation.
+type MockLog struct {
+	Traces        []string
+	Debugs        []string
+	Infos         []string
+	Warns         []string
+	Errors        []string
+	Fields        []map[string]string
+	MappingFields []any
+}
+
+// WithFields adds fields to the MockLog message.
+func (m *MockLog) WithFields(fields map[string]string) log.Modular {
+	m.Fields = append(m.Fields, fields)
+	return m
+}
+
+// With adds mapping fields to the MockLog message.
+func (m *MockLog) With(args ...any) log.Modular {
+	m.MappingFields = append(m.MappingFields, args...)
+	return m
+}
+
+// Fatal logs a fatal error message with a given format.
+func (m *MockLog) Fatal(format string, v ...any) {}
+
+// Error logs an error message with a given format.
+func (m *MockLog) Error(format string, v ...any) {
+	m.Errors = append(m.Errors, fmt.Sprintf(format, v...))
+}
+
+// Warn logs a warning message with a given format.
+func (m *MockLog) Warn(format string, v ...any) {
+	m.Warns = append(m.Warns, fmt.Sprintf(format, v...))
+}
+
+// Info logs an info message with a given format.
+func (m *MockLog) Info(format string, v ...any) {
+	m.Infos = append(m.Infos, fmt.Sprintf(format, v...))
+}
+
+// Debug logs a debug message with a given format.
+func (m *MockLog) Debug(format string, v ...any) {
+	m.Debugs = append(m.Debugs, fmt.Sprintf(format, v...))
+}
+
+// Trace logs a trace message with a given format.
+func (m *MockLog) Trace(format string, v ...any) {
+	m.Traces = append(m.Traces, fmt.Sprintf(format, v...))
+}
+
+// Fatalln logs a fatal error message.
+func (m *MockLog) Fatalln(message string) {}
+
+// Errorln logs an error message.
+func (m *MockLog) Errorln(message string) {
+	m.Errors = append(m.Errors, message)
+}
+
+// Warnln logs a warning message.
+func (m *MockLog) Warnln(message string) {
+	m.Warns = append(m.Warns, message)
+}
+
+// Infoln logs an info message.
+func (m *MockLog) Infoln(message string) {
+	m.Infos = append(m.Infos, message)
+}
+
+// Debugln logs a debug message.
+func (m *MockLog) Debugln(message string) {
+	m.Debugs = append(m.Debugs, message)
+}
+
+// Traceln logs a trace message.
+func (m *MockLog) Traceln(message string) {
+	m.Traces = append(m.Traces, message)
+}


### PR DESCRIPTION
I added this test to get a discussion going on the logs emitted by the `branch` processor. As pointed out in https://github.com/redpanda-data/connect/issues/2333, they can be excessive in some cases.