### PR TITLE
Add label metadata in template mapping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,13 @@ Changelog
 
 All notable changes to this project will be documented in this file.
 
+## 4.43.0 - TBD
+
+### Added
+
+- Field `label` added to the template tests definitions. (@mihaitodor)
+- Metadata field `label` can now be utilized within a template's `mapping` field to access the label that is associated with the template instantiation in a config.
+
 ## 4.42.0 - 2024-11-29
 
 ### Added

--- a/internal/template/config.go
+++ b/internal/template/config.go
@@ -31,6 +31,7 @@ type FieldConfig struct {
 // TestConfig defines a unit test for the template.
 type TestConfig struct {
 	Name     string    `yaml:"name"`
+	Label    string    `yaml:"label"`
 	Config   yaml.Node `yaml:"config"`
 	Expected yaml.Node `yaml:"expected,omitempty"`
 }
@@ -157,7 +158,7 @@ func (c Config) Test(env *bundle.Environment, benv *bloblang.Environment) ([]str
 
 	var failures []string
 	for _, test := range c.Tests {
-		outConf, err := compiled.Render(&test.Config)
+		outConf, err := compiled.Render(&test.Config, test.Label)
 		if err != nil {
 			return nil, fmt.Errorf("test '%v': %w", test.Name, err)
 		}
@@ -269,6 +270,7 @@ func ConfigSpec() docs.FieldSpecs {
 			"tests", "Optional unit test definitions for the template that verify certain configurations produce valid configs. These tests are executed with the command `rpk connect template lint`.",
 		).Array().WithChildren(
 			docs.FieldString("name", "A name to identify the test."),
+			docs.FieldString("label", "A label to assign to this template when running the test.").HasDefault(""),
 			docs.FieldObject("config", "A configuration to run this test with, the config resulting from applying the template with this config will be linted."),
 			docs.FieldObject("expected", "An optional configuration describing the expected result of applying the template, when specified the result will be diffed and any mismatching fields will be reported as a test error.").Optional(),
 		).HasDefault([]any{}),

--- a/internal/template/template.go
+++ b/internal/template/template.go
@@ -54,7 +54,7 @@ type compiled struct {
 }
 
 // Render a compiled template by providing a generic config.
-func (c *compiled) Render(node any) (any, error) {
+func (c *compiled) Render(node any, label string) (any, error) {
 	var genericConf any
 	var err error
 	switch t := node.(type) {
@@ -69,6 +69,7 @@ func (c *compiled) Render(node any) (any, error) {
 
 	part := message.NewPart(nil)
 	part.SetStructuredMut(genericConf)
+	part.MetaSetMut("label", label)
 	msg := message.Batch{part}
 
 	newPart, err := c.mapping.MapPart(0, msg)
@@ -130,7 +131,7 @@ func WithMetricsMapping(nm bundle.NewManagement, m *metrics.Mapping) bundle.NewM
 
 func registerCacheTemplate(tmpl *compiled, env *bundle.Environment) error {
 	return env.CacheAdd(func(c cache.Config, nm bundle.NewManagement) (cache.V1, error) {
-		newConf, err := tmpl.Render(c.Plugin)
+		newConf, err := tmpl.Render(c.Plugin, nm.Label())
 		if err != nil {
 			return nil, err
 		}
@@ -151,7 +152,7 @@ func registerCacheTemplate(tmpl *compiled, env *bundle.Environment) error {
 
 func registerInputTemplate(tmpl *compiled, env *bundle.Environment) error {
 	return env.InputAdd(func(c input.Config, nm bundle.NewManagement) (input.Streamed, error) {
-		newConf, err := tmpl.Render(c.Plugin)
+		newConf, err := tmpl.Render(c.Plugin, nm.Label())
 		if err != nil {
 			return nil, err
 		}
@@ -175,7 +176,7 @@ func registerInputTemplate(tmpl *compiled, env *bundle.Environment) error {
 
 func registerOutputTemplate(tmpl *compiled, env *bundle.Environment) error {
 	return env.OutputAdd(func(c output.Config, nm bundle.NewManagement, pcf ...processor.PipelineConstructorFunc) (output.Streamed, error) {
-		newConf, err := tmpl.Render(c.Plugin)
+		newConf, err := tmpl.Render(c.Plugin, nm.Label())
 		if err != nil {
 			return nil, err
 		}
@@ -199,7 +200,7 @@ func registerOutputTemplate(tmpl *compiled, env *bundle.Environment) error {
 
 func registerProcessorTemplate(tmpl *compiled, env *bundle.Environment) error {
 	return env.ProcessorAdd(func(c processor.Config, nm bundle.NewManagement) (processor.V1, error) {
-		newConf, err := tmpl.Render(c.Plugin)
+		newConf, err := tmpl.Render(c.Plugin, nm.Label())
 		if err != nil {
 			return nil, err
 		}
@@ -220,7 +221,7 @@ func registerProcessorTemplate(tmpl *compiled, env *bundle.Environment) error {
 
 func registerRateLimitTemplate(tmpl *compiled, env *bundle.Environment) error {
 	return env.RateLimitAdd(func(c ratelimit.Config, nm bundle.NewManagement) (ratelimit.V1, error) {
-		newConf, err := tmpl.Render(c.Plugin)
+		newConf, err := tmpl.Render(c.Plugin, nm.Label())
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
I could inject the test name as the label. Just thought it's nicer to have an explicit field.

Example usage:

`test.tmpl.yaml`:
```yaml
name: foobar
type: input

mapping: |
  root.generate = {
    "count": 1,
    "mapping": "root = \"" + @label.or("") + "\""
  }

tests:
  - name: foobar test
    label: quack
    config: {}
    expected:
      generate:
        count: 1
        mapping: root = "quack"
```

`test.yaml`:
```yaml
input:
  label: meow
  foobar: {}
```

Test:
```shell
$ benthos template lint test.tmpl.yaml 
$ benthos run -t test.tmpl.yaml test.yaml
INFO Running main config from specified file       @service=benthos benthos_version=82851b0cfc4009c48115b56d4743848193def0d8 path=test.yaml
INFO Listening for HTTP requests at: http://0.0.0.0:4195  @service=benthos
INFO Launching a Benthos instance, use CTRL+C to close  @service=benthos
INFO Output type stdout is now active              @service=benthos label="" path=root.output
INFO Input type generate is now active             @service=benthos label="" path=root.input
meow
INFO Pipeline has terminated. Shutting down the service  @service=benthos
```