### PR TITLE
Add `error_source_*` bloblang functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to this project will be documented in this file.
 - Metadata field `label` can now be utilized within a template's `mapping` field to access the label that is associated with the template instantiation in a config. (@mihaitodor)
 - `bloblang` scalar type added to template fields. (@mihaitodor)
 - Go API: Method `SetOutputBrokerPattern` added to the `StreamBuilder` type. (@mihaitodor)
+- New `error_source_name`, `error_source_label` and `error_source_path` bloblang functions. (@mihaitodor)
 
 ### Changed
 

--- a/internal/bloblang/query/errors.go
+++ b/internal/bloblang/query/errors.go
@@ -15,6 +15,8 @@ type ErrNoContext struct {
 	FieldName string
 }
 
+var _ error = &ErrNoContext{}
+
 // Error returns an attempt at a useful error message.
 func (e ErrNoContext) Error() string {
 	if e.FieldName != "" {
@@ -29,6 +31,8 @@ type errFrom struct {
 	from Function
 	err  error
 }
+
+var _ error = &errFrom{}
 
 func (e *errFrom) Error() string {
 	return fmt.Sprintf("%v: %v", e.from.Annotation(), e.err)
@@ -71,6 +75,8 @@ type TypeMismatch struct {
 	Operation string
 }
 
+var _ error = &TypeMismatch{}
+
 // Error implements the standard error interface.
 func (t *TypeMismatch) Error() string {
 	return fmt.Sprintf("cannot %v types %v (from %v) and %v (from %v)", t.Operation, t.Left, t.Lfn.Annotation(), t.Right, t.Rfn.Annotation())
@@ -85,4 +91,27 @@ func NewTypeMismatch(operation string, lfn, rfn Function, left, right any) *Type
 		Right:     value.ITypeOf(right),
 		Operation: operation,
 	}
+}
+
+//------------------------------------------------------------------------------
+
+// ComponentError is an error that could be returned by a component annotated by
+// its label and path.
+type ComponentError struct {
+	Err   error
+	Name  string
+	Label string
+	Path  []string
+}
+
+var _ error = &ComponentError{}
+
+// Error returns a formatted error string.
+func (e *ComponentError) Error() string {
+	return e.Err.Error()
+}
+
+// Unwrap returns the underlying error value.
+func (e *ComponentError) Unwrap() error {
+	return e.Err
 }

--- a/internal/bloblang/query/functions.go
+++ b/internal/bloblang/query/functions.go
@@ -346,9 +346,8 @@ var _ = registerSimpleFunction(
 		),
 	),
 	func(ctx FunctionContext) (any, error) {
-		v := ctx.MsgBatch.Get(ctx.Index).ErrorGet()
-		if v != nil {
-			return v.Error(), nil
+		if err := ctx.MsgBatch.Get(ctx.Index).ErrorGet(); err != nil {
+			return err.Error(), nil
 		}
 		return nil, nil
 	},
@@ -364,6 +363,60 @@ var _ = registerSimpleFunction(
 	),
 	func(ctx FunctionContext) (any, error) {
 		return ctx.MsgBatch.Get(ctx.Index).ErrorGet() != nil, nil
+	},
+)
+
+var _ = registerSimpleFunction(
+	NewFunctionSpec(
+		FunctionCategoryMessage, "error_source_name",
+		"Returns the name of the source component which raised the error during the processing of a message. `null` is returned when the error is null or no source component is associated with it. For more information about error handling patterns read xref:configuration:error_handling.adoc[].",
+		NewExampleSpec("",
+			`root.doc.error_source_name = error_source_name()`,
+		),
+	),
+	func(ctx FunctionContext) (any, error) {
+		if err := ctx.MsgBatch.Get(ctx.Index).ErrorGet(); err != nil {
+			if cErr, ok := err.(*ComponentError); ok {
+				return cErr.Name, nil
+			}
+		}
+		return nil, nil
+	},
+)
+
+var _ = registerSimpleFunction(
+	NewFunctionSpec(
+		FunctionCategoryMessage, "error_source_label",
+		"Returns the label of the source component which raised the error during the processing of a message or an empty string if not set. `null` is returned when the error is null or no source component is associated with it. For more information about error handling patterns read xref:configuration:error_handling.adoc[].",
+		NewExampleSpec("",
+			`root.doc.error_source_label = error_source_label()`,
+		),
+	),
+	func(ctx FunctionContext) (any, error) {
+		if err := ctx.MsgBatch.Get(ctx.Index).ErrorGet(); err != nil {
+			if cErr, ok := err.(*ComponentError); ok {
+				return cErr.Label, nil
+			}
+		}
+		return nil, nil
+	},
+)
+
+var _ = registerSimpleFunction(
+	NewFunctionSpec(
+		FunctionCategoryMessage, "error_source_path",
+		"Returns the path of the source component which raised the error during the processing of a message. `null` is returned when the error is null or no source component is associated with it. For more information about error handling patterns read xref:configuration:error_handling.adoc[].",
+		NewExampleSpec("",
+			`root.doc.error_source_path = error_source_path()`,
+		),
+	),
+	func(ctx FunctionContext) (any, error) {
+		if err := ctx.MsgBatch.Get(ctx.Index).ErrorGet(); err != nil {
+			if cErr, ok := err.(*ComponentError); ok {
+				return SliceToDotPath(cErr.Path...), nil
+			}
+		}
+		return nil, nil
 	},
 )
 

--- a/internal/component/errors.go
+++ b/internal/component/errors.go
@@ -36,28 +36,6 @@ func ErrInvalidType(typeStr, tried string) error {
 
 //------------------------------------------------------------------------------
 
-// LabelledError is an error that could be returned by components annotated by
-// their label (or path) in order to provide extra context to which specific
-// component within a config is yielding it. This is particularly useful in
-// situations such as ConnectionStatus aggregates where a broker yields multiple
-// errors from a range of child components.
-type LabelledError struct {
-	Label string
-	Err   error
-}
-
-// Error returns a formatted error string.
-func (e *LabelledError) Error() string {
-	return fmt.Sprintf("%v: %v", e.Label, e.Err)
-}
-
-// Unwrap returns the underlying error value.
-func (e *LabelledError) Unwrap() error {
-	return e.Err
-}
-
-//------------------------------------------------------------------------------
-
 // Errors used throughout the codebase.
 var (
 	ErrTimeout    = errors.New("action timed out")

--- a/internal/component/processor/auto_observed.go
+++ b/internal/component/processor/auto_observed.go
@@ -6,6 +6,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/redpanda-data/benthos/v4/internal/bloblang/query"
 	"github.com/redpanda-data/benthos/v4/internal/component"
 	"github.com/redpanda-data/benthos/v4/internal/component/metrics"
 	"github.com/redpanda-data/benthos/v4/internal/log"
@@ -141,6 +142,9 @@ func TestBatchProcContext(ctx context.Context, spans []*tracing.Span, parts []*m
 // accessing processor specific spans.
 type BatchProcContext struct {
 	ctx   context.Context
+	name  string
+	label string
+	path  []string
 	spans []*tracing.Span
 	parts []*message.Part
 
@@ -183,6 +187,15 @@ func (b *BatchProcContext) OnError(err error, index int, p *message.Part) {
 	if p == nil && len(b.parts) > index && index >= 0 {
 		p = b.parts[index]
 	}
+
+	if err != nil {
+		err = &query.ComponentError{
+			Err:   err,
+			Name:  b.name,
+			Label: b.label,
+			Path:  b.path,
+		}
+	}
 	MarkErr(p, span, err)
 }
 
@@ -224,6 +237,9 @@ func (a *v2BatchedToV1Processor) ProcessBatch(ctx context.Context, msg message.B
 
 	outputBatches, err := a.p.ProcessBatch(&BatchProcContext{
 		ctx:    ctx,
+		name:   a.typeStr,
+		label:  a.mgr.Label(),
+		path:   a.mgr.Path(),
 		spans:  spans,
 		parts:  msg,
 		mError: a.mError,

--- a/public/service/errors_test.go
+++ b/public/service/errors_test.go
@@ -3,12 +3,19 @@
 package service
 
 import (
+	"context"
 	"errors"
 	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+
+	"github.com/redpanda-data/benthos/v4/internal/component/processor"
+	"github.com/redpanda-data/benthos/v4/internal/docs"
+	"github.com/redpanda-data/benthos/v4/internal/manager"
+	"github.com/redpanda-data/benthos/v4/internal/message"
+	"github.com/redpanda-data/benthos/v4/internal/template"
 )
 
 func TestMockWalkableError(t *testing.T) {
@@ -123,4 +130,124 @@ func TestBatchErrorIndexedBy(t *testing.T) {
 		{i: 2, c: "c", e: ""},
 		{i: 1, c: "b", e: "b error"},
 	}, results)
+}
+
+func TestBloblangErrorFuncs(t *testing.T) {
+	resourceProcessorName := "foobar_resource"
+	processorTemplateName := "foobar_template"
+	tests := []struct {
+		name      string
+		label     string
+		processor string
+		expected  string
+	}{
+		{
+			name:      "returns null when no error is set",
+			label:     "foobar_label",
+			processor: `mapping: root = this`,
+			expected:  `{"error": null, "name": null, "label": null, "path": null}`,
+		},
+		{
+			name:      "returns the label when set for a standard processor",
+			label:     "foobar_label",
+			processor: `mapping: root = throw("Kaboom!")`,
+			expected:  `{"error":"failed assignment (line 1): Kaboom!", "name": "mapping", "label": "foobar_label", "path": "processors.0.try.1"}`,
+		},
+		{
+			name:      "returns an empty label when not set for a standard processor",
+			processor: `mapping: root = throw("Kaboom!")`,
+			expected:  `{"error":"failed assignment (line 1): Kaboom!", "name": "mapping", "label": "", "path": "processors.0.try.1"}`,
+		},
+		{
+			name:      "returns the label of a processor resource",
+			label:     "foobar_label",
+			processor: fmt.Sprintf("resource: %s", resourceProcessorName),
+			expected:  `{"error":"failed assignment (line 1): Kaboom!", "name": "mapping", "label": "foobar_label", "path": "processor_resources.processors.1"}`,
+		},
+		{
+			name:      "returns an empty label when not set for a processor resource",
+			label:     "",
+			processor: fmt.Sprintf("resource: %s", resourceProcessorName),
+			expected:  `{"error":"failed assignment (line 1): Kaboom!", "name": "mapping", "label": "", "path": "processor_resources.processors.1"}`,
+		},
+		{
+			name:      "returns the label set on a processor inside a processor template",
+			label:     "foobar_label",
+			processor: fmt.Sprintf(`%s: {}`, processorTemplateName),
+			expected:  `{"error":"failed assignment (line 1): Kaboom!", "name": "mapping", "label": "foobar_label", "path": "processors.0.try.1.processors.1"}`,
+		},
+		{
+			name:      "returns an empty label when not set for a processor template",
+			label:     "",
+			processor: fmt.Sprintf(`%s: {}`, processorTemplateName),
+			expected:  `{"error":"failed assignment (line 1): Kaboom!", "name": "mapping", "label": "", "path": "processors.0.try.1.processors.1"}`,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			mgr, err := manager.New(manager.NewResourceConfig())
+			require.NoError(t, err)
+
+			// Register a resource processor
+			resProcConf, err := docs.UnmarshalYAML([]byte(fmt.Sprintf(`
+processors:
+  - mapping: root.foo = "bar"
+  - label: %s
+    mapping: root = throw("Kaboom!")
+`, test.label)))
+			require.NoError(t, err)
+
+			resProc, err := processor.FromAny(mgr, resProcConf)
+			require.NoError(t, err)
+
+			// TODO: Should `StoreProcessor()` use `resProc.Label` as the name instead of taking an extra parameter?
+			err = mgr.StoreProcessor(context.Background(), resourceProcessorName, resProc)
+			require.NoError(t, err)
+
+			// Register a processor template
+			err = template.RegisterTemplateYAML(mgr.Environment(), mgr.BloblEnvironment(), []byte(fmt.Sprintf(`
+name: %s
+type: processor
+
+mapping: |
+  root.processors = []
+  root.processors."-".mapping = """root.foo = "bar" """
+  root.processors."-" = {
+      "label": @label,
+      "mapping": """root = throw("Kaboom!")"""
+    }
+`, processorTemplateName)))
+			require.NoError(t, err)
+
+			// Configure a `processors` processor which exercises the `error_source_*` functions
+			conf, err := docs.UnmarshalYAML([]byte(fmt.Sprintf(`
+processors:
+  # Use a try to make the path more interesting
+  - try:
+    - mapping: root.foo = "bar"
+    - label: %s
+      %s
+  # Don't use a catch so we can exercise the functions even when there is no error
+  - mapping: |
+      root.error = error()
+      root.name = error_source_name()
+      root.label = error_source_label()
+      root.path = error_source_path()
+`, test.label, test.processor)))
+			require.NoError(t, err)
+
+			parsedConf, err := processor.FromAny(mgr, conf)
+			require.NoError(t, err)
+
+			proc, err := mgr.NewProcessor(parsedConf)
+			require.NoError(t, err)
+
+			outMsgs, err := proc.ProcessBatch(context.Background(), message.QuickBatch([][]byte{nil}))
+			require.NoError(t, err)
+			require.Len(t, outMsgs, 1)
+			msg := outMsgs[0].Get(0)
+			assert.JSONEq(t, test.expected, string(msg.AsBytes()))
+		})
+	}
 }


### PR DESCRIPTION
- `error_source_name()`: Returns the name of the component which raised the error.
- `error_source_label()`: Returns the label of the component which raised the error.
- `error_source_path()`: Returns the config path of the conponent which raised the error.

One use case for these is to determine which processor generated an error within a `try` processor.

I thought about having only `error_source_label()` and returning the path when the label is not set, but it feels handy to be able to quickly print both the label and the path.

When using the same processor resource multiple times in a config, these functions won't help users figure out which config section caused the error, since the path is relative to
`processor_resources`. Templates don't have this issue because the path will be derived from the config itself and one can now even namespace the subcomponent label using the new `@label` metadata in the template `mapping`.