### PR TITLE
Add new `StreamBuilder.SetOutputBrokerPattern` API

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 - Field `label` added to the template tests definitions. (@mihaitodor)
 - Metadata field `label` can now be utilized within a template's `mapping` field to access the label that is associated with the template instantiation in a config. (@mihaitodor)
 - `bloblang` scalar type added to template fields. (@mihaitodor)
+- Go API: Method `SetOutputBrokerPattern` added to the `StreamBuilder` type. (@mihaitodor)
 
 ### Changed
 

--- a/internal/impl/pure/output_broker.go
+++ b/internal/impl/pure/output_broker.go
@@ -81,9 +81,14 @@ The greedy pattern results in higher output throughput at the cost of potentiall
 				Advanced().
 				Default(1),
 			service.NewStringEnumField(boFieldPattern,
-				"fan_out", "fan_out_fail_fast", "fan_out_sequential", "fan_out_sequential_fail_fast", "round_robin", "greedy").
+				string(service.OutputBrokerPatternFanOut),
+				string(service.OutputBrokerPatternFanOutFailFast),
+				string(service.OutputBrokerPatternFanOutSequential),
+				string(service.OutputBrokerPatternFanOutSequentialFailFast),
+				string(service.OutputBrokerPatternRoundRobin),
+				string(service.OutputBrokerPatternGreedy)).
 				Description("The brokering pattern to use.").
-				Default("fan_out"),
+				Default(string(service.OutputBrokerPatternFanOut)),
 			service.NewOutputListField(boFieldOutputs).
 				Description("A list of child outputs to broker."),
 			service.NewBatchPolicyField(boFieldBatching),
@@ -140,10 +145,10 @@ func brokerOutputFromParsed(conf *service.ParsedConfig, res *service.Resources) 
 		}
 	}
 
-	_, isRetryWrapped := map[string]struct{}{
-		"fan_out":            {},
-		"fan_out_sequential": {},
-	}[pattern]
+	_, isRetryWrapped := map[service.OutputBrokerPatternType]struct{}{
+		service.OutputBrokerPatternFanOut:           {},
+		service.OutputBrokerPatternFanOutSequential: {},
+	}[service.OutputBrokerPatternType(pattern)]
 
 	var outputs []output.Streamed
 	{
@@ -191,14 +196,14 @@ func brokerOutputFromParsed(conf *service.ParsedConfig, res *service.Resources) 
 	}
 
 	var b output.Streamed
-	switch pattern {
-	case "fan_out", "fan_out_fail_fast":
+	switch service.OutputBrokerPatternType(pattern) {
+	case service.OutputBrokerPatternFanOut, service.OutputBrokerPatternFanOutFailFast:
 		b, err = newFanOutOutputBroker(outputs)
-	case "fan_out_sequential", "fan_out_sequential_fail_fast":
+	case service.OutputBrokerPatternFanOutSequential, service.OutputBrokerPatternFanOutSequentialFailFast:
 		b, err = newFanOutSequentialOutputBroker(outputs)
-	case "round_robin":
+	case service.OutputBrokerPatternRoundRobin:
 		b, err = newRoundRobinOutputBroker(outputs)
-	case "greedy":
+	case service.OutputBrokerPatternGreedy:
 		b, err = newGreedyOutputBroker(outputs)
 	default:
 		return nil, fmt.Errorf("broker pattern was not recognised: %v", pattern)

--- a/public/service/output.go
+++ b/public/service/output.go
@@ -371,3 +371,26 @@ func OutputPerformanceDocs(benefitsFromMaxInFlight, benefitsFromBatching bool) (
 	}
 	return content
 }
+
+//------------------------------------------------------------------------------
+
+// OutputBrokerPatternType describes the brokering pattern type for a broker output.
+type OutputBrokerPatternType string
+
+const (
+	// OutputBrokerPatternFanOut sends each message to all outputs in parallel.
+	OutputBrokerPatternFanOut OutputBrokerPatternType = "fan_out"
+	// OutputBrokerPatternFanOutFailFast sends each message to all outputs in parallel and output failures will not be
+	// automatically retried.
+	OutputBrokerPatternFanOutFailFast OutputBrokerPatternType = "fan_out_fail_fast"
+	// OutputBrokerPatternFanOutSequential sends each message to all outputs sequentially.
+	OutputBrokerPatternFanOutSequential OutputBrokerPatternType = "fan_out_sequential"
+	// OutputBrokerPatternFanOutSequentialFailFast sends each message to all outputs sequentially and output failures
+	// will not be automatically retried.
+	OutputBrokerPatternFanOutSequentialFailFast OutputBrokerPatternType = "fan_out_sequential_fail_fast"
+	// OutputBrokerPatternRoundRobin sends each message to a single output following their order.
+	OutputBrokerPatternRoundRobin OutputBrokerPatternType = "round_robin"
+	// OutputBrokerPatternGreedy sends each message to a single output, which is determined by allowing outputs to claim
+	// messages as soon as they are able to process them.
+	OutputBrokerPatternGreedy OutputBrokerPatternType = "greedy"
+)

--- a/public/service/stream_builder.go
+++ b/public/service/stream_builder.go
@@ -65,10 +65,11 @@ type StreamBuilder struct {
 	apiMut       manager.APIReg
 	customLogger log.Modular
 
-	configSpec      docs.FieldSpecs
-	env             *Environment
-	lintingDisabled bool
-	envVarLookupFn  func(string) (string, bool)
+	configSpec          docs.FieldSpecs
+	env                 *Environment
+	lintingDisabled     bool
+	envVarLookupFn      func(string) (string, bool)
+	outputBrokerPattern OutputBrokerPatternType
 }
 
 // NewStreamBuilder creates a new StreamBuilder.
@@ -143,6 +144,13 @@ func (s *StreamBuilder) SetEnvVarLookupFunc(fn func(string) (string, bool)) {
 // will match the number of logical CPUs on the machine.
 func (s *StreamBuilder) SetThreads(n int) {
 	s.threads = n
+}
+
+// SetOutputBrokerPattern changes the pattern used for brokering messages when
+// multiple outputs are added via AddOutputYAML or when AddConsumerFunc is used.
+// The default pattern is `fan_out`.
+func (s *StreamBuilder) SetOutputBrokerPattern(pattern OutputBrokerPatternType) {
+	s.outputBrokerPattern = pattern
 }
 
 // PrintLogger is a simple Print based interface implemented by custom loggers.
@@ -331,8 +339,8 @@ func (s *StreamBuilder) AddProcessorYAML(conf string) error {
 
 // AddConsumerFunc adds an output to the builder that executes a closure
 // function argument for each message. If more than one output configuration is
-// added they will automatically be composed within a fan out broker when the
-// pipeline is built.
+// added they will automatically be composed within a broker (default `fan_out`)
+// when the pipeline is built.
 //
 // The provided MessageHandlerFunc may be called from any number of goroutines,
 // and therefore it is recommended to implement some form of throttling or mutex
@@ -370,8 +378,8 @@ func (s *StreamBuilder) AddConsumerFunc(fn MessageHandlerFunc) error {
 
 // AddBatchConsumerFunc adds an output to the builder that executes a closure
 // function argument for each message batch. If more than one output
-// configuration is added they will automatically be composed within a fan out
-// broker when the pipeline is built.
+// configuration is added they will automatically be composed within a broker
+// (default `fan_out`) when the pipeline is built.
 //
 // The provided MessageBatchHandlerFunc may be called from any number of
 // goroutines, and therefore it is recommended to implement some form of
@@ -406,7 +414,7 @@ func (s *StreamBuilder) AddBatchConsumerFunc(fn MessageBatchHandlerFunc) error {
 
 // AddOutputYAML parses an output YAML configuration and adds it to the builder.
 // If more than one output configuration is added they will automatically be
-// composed within a fan out broker when the pipeline is built.
+// composed within a broker (default `fan_out`) when the pipeline is built.
 func (s *StreamBuilder) AddOutputYAML(conf string) error {
 	nconf, err := s.getYAMLNode([]byte(conf))
 	if err != nil {
@@ -960,9 +968,13 @@ func (s *StreamBuilder) buildConfig() builderConfig {
 		for i, v := range s.outputs {
 			iSlice[i] = v
 		}
-		conf.Output.Plugin = map[string]any{
+		broker := map[string]any{
 			"outputs": iSlice,
 		}
+		if s.outputBrokerPattern != "" {
+			broker["pattern"] = string(s.outputBrokerPattern)
+		}
+		conf.Output.Plugin = broker
 	} else {
 		// TODO: V5 Prevent default input/output
 		conf.Output = output.NewConfig()

--- a/public/service/stream_builder_test/stream_builder_test.go
+++ b/public/service/stream_builder_test/stream_builder_test.go
@@ -90,3 +90,86 @@ input:
 		require.Fail(t, "timeout waiting for ack error")
 	}
 }
+
+type foobarOutput struct {
+	recvChan chan struct{}
+}
+
+func newFoobarOutput() *foobarOutput {
+	return &foobarOutput{
+		recvChan: make(chan struct{}),
+	}
+}
+
+func (i *foobarOutput) Connect(context.Context) error {
+	return nil
+}
+
+func (i *foobarOutput) Write(context.Context, *service.Message) error {
+	// Delay the write to ensure that if this output is utilized in a broker which lacks `pattern: fan_out_sequential`,
+	// the other output will receive the message first.
+	time.Sleep(100 * time.Millisecond)
+
+	close(i.recvChan)
+
+	return nil
+}
+
+func (i *foobarOutput) Close(context.Context) error {
+	return nil
+}
+
+func TestStreamSetOutputBrokerPattern(t *testing.T) {
+	output := newFoobarOutput()
+
+	// This test sits in its own package so it will get a fresh `service.GlobalEnvironment()` that we can alter safely.
+	err := service.RegisterOutput("foobar", service.NewConfigSpec(),
+		func(_ *service.ParsedConfig, mgr *service.Resources) (service.Output, int, error) {
+			return output, 1, nil
+		},
+	)
+	require.NoError(t, err)
+
+	streamBuilder := service.NewStreamBuilder()
+	require.NoError(t, streamBuilder.AddInputYAML(`
+generate:
+  count: 1
+  mapping: root.foo = "bar"
+`))
+	require.NoError(t, streamBuilder.AddOutputYAML(`
+foobar: {}
+`))
+	require.NoError(t, streamBuilder.SetLoggerYAML("level: OFF"))
+
+	consumerRecvChan := make(chan struct{})
+	require.NoError(t, streamBuilder.AddConsumerFunc(func(context.Context, *service.Message) error {
+		close(consumerRecvChan)
+
+		return nil
+	}))
+
+	streamBuilder.SetOutputBrokerPattern(service.OutputBrokerPatternFanOutSequential)
+
+	stream, err := streamBuilder.Build()
+	require.NoError(t, err)
+
+	closeChan := make(chan struct{})
+	go func() {
+		require.NoError(t, stream.Run(context.Background()))
+		close(closeChan)
+	}()
+
+	select {
+	case <-output.recvChan:
+		select {
+		case <-consumerRecvChan:
+			// The foobar output received the message followed by the consumer func as expected.
+		case <-time.After(1 * time.Second):
+			require.Fail(t, "the consumer func did not receive the message")
+		}
+	case <-consumerRecvChan:
+		require.Fail(t, "the foobar output should have received the message first")
+	case <-time.After(1 * time.Second):
+		require.Fail(t, "deadlock detected")
+	}
+}


### PR DESCRIPTION
This allows users to configure the output brokering pattern for streams constructed programatically via the StreamBuilder APIs.