### PR TITLE
Fix the values for the level field of the log processor

### DIFF
--- a/internal/impl/pure/processor_log.go
+++ b/internal/impl/pure/processor_log.go
@@ -51,7 +51,7 @@ pipeline:
 `+"```"+`
 `).
 		Fields(
-			service.NewStringEnumField(logPFieldLevel, "ERROR", "WARN", "INFO", "DEBUG", "TRACE", "ALL").
+			service.NewStringEnumField(logPFieldLevel, "ERROR", "WARN", "INFO", "DEBUG", "TRACE").
 				Description("The log level to use.").
 				LintRule(``).
 				Default("INFO"),


### PR DESCRIPTION
We don't support `ALL`.