### PR TITLE
Add TLS client authentication for socket_server

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ Changelog
 
 All notable changes to this project will be documented in this file.
 
+## 4.48.0 - TBD
+
+### Added
+
+- Field `client_auth` added to the `socket_server` input. (@filippog)
+
 ## 4.47.0 - 2025-04-03
 
 ### Added

--- a/internal/impl/io/input_socket_server.go
+++ b/internal/impl/io/input_socket_server.go
@@ -27,13 +27,19 @@ import (
 )
 
 const (
-	issFieldNetwork       = "network"
-	issFieldAddress       = "address"
-	issFieldAddressCache  = "address_cache"
-	issFieldTLS           = "tls"
-	issFieldTLSCertFile   = "cert_file"
-	issFieldTLSKeyFile    = "key_file"
-	issFieldTLSSelfSigned = "self_signed"
+	issFieldNetwork                    = "network"
+	issFieldAddress                    = "address"
+	issFieldAddressCache               = "address_cache"
+	issFieldTLS                        = "tls"
+	issFieldTLSCertFile                = "cert_file"
+	issFieldTLSKeyFile                 = "key_file"
+	issFieldTLSSelfSigned              = "self_signed"
+	issFieldTLSClientAuth              = "client_auth"
+	issFieldTLSClientAuthNoClientCert  = "no"
+	issFieldTLSClientAuthRequestCert   = "request"
+	issFieldTLSClientAuthRequireAny    = "require_any"
+	issFieldTLSClientAuthRequireValid  = "require_valid"
+	issFieldTLSClientAuthVerifyIfGiven = "verify_if_given"
 )
 
 func socketServerInputSpec() *service.ConfigSpec {
@@ -61,6 +67,16 @@ func socketServerInputSpec() *service.ConfigSpec {
 				service.NewBoolField(issFieldTLSSelfSigned).
 					Description("Whether to generate self signed certificates.").
 					Default(false),
+				service.NewStringAnnotatedEnumField(issFieldTLSClientAuth, map[string]string{
+					issFieldTLSClientAuthNoClientCert:  "client certificate is not requested nor required.",
+					issFieldTLSClientAuthRequestCert:   "will request client certificate, not require it.",
+					issFieldTLSClientAuthRequireAny:    "will accept any client certificate, even if not valid.",
+					issFieldTLSClientAuthRequireValid:  "requires a valid client certificate.",
+					issFieldTLSClientAuthVerifyIfGiven: "will verify a certificate, if one is sent by the client.",
+				}).
+					Description("How client authentication is handled.").
+					Default(issFieldTLSClientAuthNoClientCert).
+					Version("4.44.1"),
 			).
 				Description("TLS specific configuration, valid when the `network` is set to `tls`.").
 				Optional(),
@@ -101,6 +117,7 @@ type socketServerInput struct {
 	tlsCert       string
 	tlsKey        string
 	tlsSelfSigned bool
+	tlsClientAuth tls.ClientAuthType
 	codecCtor     codec.DeprecatedFallbackCodec
 
 	messages chan service.MessageBatch
@@ -128,6 +145,22 @@ func newSocketServerInputFromParsed(conf *service.ParsedConfig, mgr *service.Res
 	t.tlsKey, _ = tlsConf.FieldString(issFieldTLSKeyFile)
 	t.tlsSelfSigned, _ = tlsConf.FieldBool(issFieldTLSSelfSigned)
 
+	tlsConfClientAuth, _ := tlsConf.FieldString(issFieldTLSClientAuth)
+	switch tlsConfClientAuth {
+	case issFieldTLSClientAuthNoClientCert:
+		t.tlsClientAuth = tls.NoClientCert
+	case issFieldTLSClientAuthRequestCert:
+		t.tlsClientAuth = tls.RequestClientCert
+	case issFieldTLSClientAuthRequireAny:
+		t.tlsClientAuth = tls.RequireAnyClientCert
+	case issFieldTLSClientAuthRequireValid:
+		t.tlsClientAuth = tls.RequireAndVerifyClientCert
+	case issFieldTLSClientAuthVerifyIfGiven:
+		t.tlsClientAuth = tls.VerifyClientCertIfGiven
+	default:
+		return
+	}
+
 	if t.codecCtor, err = codec.DeprecatedCodecFromParsed(conf); err != nil {
 		return
 	}
@@ -149,6 +182,7 @@ func (t *socketServerInput) Connect(ctx context.Context) error {
 		}
 		config := &tls.Config{
 			Certificates: []tls.Certificate{cert},
+			ClientAuth:   t.tlsClientAuth,
 		}
 		ln, err = tls.Listen("tcp", t.address, config)
 	case "udp":

--- a/internal/impl/io/input_socket_server_test.go
+++ b/internal/impl/io/input_socket_server_test.go
@@ -4,9 +4,15 @@ package io_test
 
 import (
 	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
 	"crypto/tls"
+	"crypto/x509"
+	"encoding/pem"
 	"errors"
 	"fmt"
+	"math/big"
 	"net"
 	"path/filepath"
 	"sort"
@@ -1271,4 +1277,82 @@ socket_server:
 
 	wg.Wait()
 	conn.Close()
+}
+
+func TestTLSSocketServerClientAuthRequireValid(t *testing.T) {
+	tCtx, done := context.WithTimeout(context.Background(), time.Second*20)
+	defer done()
+
+	rdr, addr := socketServerInputFromConf(t, `
+socket_server:
+  network: tls
+  address: 127.0.0.1:0
+  tls:
+    self_signed: true
+    client_auth: "require_valid"
+`)
+
+	defer func() {
+		rdr.TriggerStopConsuming()
+		assert.NoError(t, rdr.WaitForClose(tCtx))
+	}()
+
+	cert, err := createSelfSignedCertificate()
+	require.NoError(t, err)
+
+	conn, err := tls.Dial("tcp", addr, &tls.Config{
+		InsecureSkipVerify: true,
+		Certificates:       []tls.Certificate{cert},
+	})
+	require.NoError(t, err)
+
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+	go func() {
+		_ = conn.SetWriteDeadline(time.Now().Add(time.Second * 5))
+
+		_, cerr := conn.Write([]byte("foo\n"))
+		require.NoError(t, cerr)
+
+		wg.Done()
+	}()
+
+	readNextMsg := func() (message.Batch, error) {
+		var tran message.Transaction
+		select {
+		case tran = <-rdr.TransactionChan():
+			require.NoError(t, tran.Ack(tCtx, nil))
+		case <-time.After(time.Second):
+			return nil, errors.New("timed out")
+		}
+		return tran.Payload, nil
+	}
+
+	_, err = readNextMsg()
+	require.Error(t, err) // we'll accept only valid certs!
+
+	wg.Wait()
+	conn.Close()
+}
+
+func createSelfSignedCertificate() (tls.Certificate, error) {
+	priv, _ := ecdsa.GenerateKey(elliptic.P521(), rand.Reader)
+	certOptions := &x509.Certificate{
+		SerialNumber: &big.Int{},
+	}
+
+	certBytes, _ := x509.CreateCertificate(rand.Reader, certOptions, certOptions, &priv.PublicKey, priv)
+	pemcert := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: certBytes})
+	key, err := x509.MarshalECPrivateKey(priv)
+	if err != nil {
+		return tls.Certificate{}, err
+	}
+
+	keyBytes := pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: key})
+	cert, err := tls.X509KeyPair(pemcert, keyBytes)
+	if err != nil {
+		return tls.Certificate{}, err
+	}
+
+	return cert, nil
 }


### PR DESCRIPTION
Present `tls.ClientAuthType` values under `tls.client_auth` of `socket_server` input.