### PR TITLE
Fix http_client input connect bug

### DIFF
--- a/public/service/codec/scanner.go
+++ b/public/service/codec/scanner.go
@@ -120,7 +120,13 @@ type codecRPublic struct {
 func (r *codecRPublic) Create(rdr io.ReadCloser, aFn service.AckFunc, details *service.ScannerSourceDetails) (DeprecatedFallbackStream, error) {
 	sDetails := service.NewScannerSourceDetails()
 	sDetails.SetName(details.Name())
-	return r.newCtor.Create(rdr, aFn, sDetails)
+
+	os, err := r.newCtor.Create(rdr, aFn, sDetails)
+	if err != nil {
+		return nil, err
+	}
+
+	return os, err
 }
 
 func (r *codecRPublic) Close(ctx context.Context) error {


### PR DESCRIPTION
This issue was uncovered because the `http_client` components would not try to reconnect if the internal codec couldn't be initialised. The fix addresses the issue at the scanner level.
    
`h.codecCtor.Create` will return a `*service.OwnedScanner`, but `h.codec` has type `codec.DeprecatedFallbackStream`, so if we get an error from `h.codecCtor.Create`, the `h.codec != nil` check in `Connect` will be true, so Benthos will think the input is connected. This can happen if the codec specification isn't compatible with the received data.