### PR TITLE
Fix the `studio` `pull` CLI subcommand to trigger `OnManagerInitialised`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ Changelog
 
 All notable changes to this project will be documented in this file.
 
+## 4.45.0 - TBD
+
+### Fixed
+
+- The `studio` `pull` CLI subcommand now triggers the `OnManagerInitialised` API hook. (@mihaitodor)
+
 ## 4.44.1 - 2025-02-06
 
 ### Fixed

--- a/internal/cli/studio/pull_runner.go
+++ b/internal/cli/studio/pull_runner.go
@@ -315,6 +315,11 @@ func (r *PullRunner) bootstrapConfigReader(ctx context.Context) (bootstrapErr er
 	}()
 
 	mgrTmp := stopMgrTmp.Manager().WithAddedMetrics(r.metrics)
+
+	if err := r.cliOpts.OnManagerInitialised(mgrTmp, nil); err != nil {
+		return fmt.Errorf("failed to execute manager initialisation hook: %w", err)
+	}
+
 	if err := r.triggerStreamReset(ctx, &conf, mgrTmp); err != nil {
 		return fmt.Errorf("failed initial stream reset: %w", err)
 	}


### PR DESCRIPTION
This allows Studio users with custom plugins to use a license as described here: https://github.com/redpanda-data/redpanda-connect-plugin-example/issues/28