### PR TITLE
Fix optional field handling in configs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ Changelog
 
 All notable changes to this project will be documented in this file.
 
+## 4.47.0 - TBD
+
+### Fixed
+
+- Fixed a bug where the `Contains()` method of `service.ParsedConfig` was returning `true` when using an optional `service.NewObjectField()` which wasn't set in the config. (@mihaitodor)
+
 ## 4.46.0 - 2025-03-20
 
 ### Added

--- a/internal/docs/format_any.go
+++ b/internal/docs/format_any.go
@@ -124,11 +124,13 @@ func (f FieldSpecs) AnyToMap(v any, conf ToValueConfig) (map[string]any, error) 
 	}
 
 	for k, v := range pendingFieldsMap {
-		defValue, err := getDefault(k, v)
+		defValue, optional, err := getDefault(k, v)
 		if err != nil {
 			if v.needsDefault() && !conf.Passive {
 				return nil, err
 			}
+			continue
+		} else if optional {
 			continue
 		}
 		m[k] = value.IClone(defValue)

--- a/internal/docs/format_yaml.go
+++ b/internal/docs/format_yaml.go
@@ -954,11 +954,13 @@ func (f FieldSpecs) YAMLToMap(node *yaml.Node, conf ToValueConfig) (map[string]a
 	}
 
 	for k, v := range pendingFieldsMap {
-		defValue, err := getDefault(k, v)
+		defValue, optional, err := getDefault(k, v)
 		if err != nil {
 			if v.needsDefault() && !conf.Passive {
 				return nil, err
 			}
+			continue
+		} else if optional {
 			continue
 		}
 		resultMap[k] = value.IClone(defValue)

--- a/public/service/config_test.go
+++ b/public/service/config_test.go
@@ -576,6 +576,20 @@ a:
 				),
 			errContains: "field 'a.b' is required and was not present in the config",
 		},
+		{
+			name: "config with empty object field and optional children retains the empty object",
+			spec: NewConfigSpec().
+				Fields(
+					NewObjectField("a",
+						NewBoolField("b").Optional(),
+					).Optional(),
+				),
+			config: `
+a: {}
+`,
+			fieldPath:     "a",
+			containsField: true,
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
The `Contains()` method of `service.ParsedConfig` was returning `true` when using an optional `service.NewObjectField()` which wasn't set in the config.

This is required for https://github.com/redpanda-data/connect/pull/3165.

Code coverage for the test I added:

```shell
$ go test -cover -coverpkg=github.com/redpanda-data/benthos/v4/internal/docs -coverprofile cover.out -run ^TestOptionalConfigFields$ github.com/redpanda-data/benthos/v4/public/service
```

<img width="831" alt="image" src="https://github.com/user-attachments/assets/b5440611-e341-457e-bae6-cd3a7e79f2a8" />
<img width="754" alt="image" src="https://github.com/user-attachments/assets/561b1ac2-2214-440f-bd18-da6287914f42" />

A few more statements are covered by the other tests.