### PR TITLE
Add uuid_v5 string method

### DIFF
--- a/internal/bloblang/query/methods_test.go
+++ b/internal/bloblang/query/methods_test.go
@@ -883,6 +883,48 @@ func TestMethods(t *testing.T) {
 			),
 			output: "1418570095",
 		},
+		"check uuid_v5 dns": {
+			input: methods(
+				literalFn("hello world"),
+				method("uuid_v5", "dns"),
+			),
+			output: "823a2f73-a936-56c3-b8b4-03641bd74f35",
+		},
+		"check uuid_v5 url": {
+			input: methods(
+				literalFn("hello world"),
+				method("uuid_v5", "url"),
+			),
+			output: "7b3d66ac-cb60-5154-8edf-0bcfd0c418b3",
+		},
+		"check uuid_v5 oid": {
+			input: methods(
+				literalFn("hello world"),
+				method("uuid_v5", "oid"),
+			),
+			output: "25024589-1a7c-5625-bdb2-81143473d4d3",
+		},
+		"check uuid_v5 x500": {
+			input: methods(
+				literalFn("hello world"),
+				method("uuid_v5", "x500"),
+			),
+			output: "dbd9b896-6d7c-5852-895c-ecc5735cf874",
+		},
+		"check uuid_v5 nil": {
+			input: methods(
+				literalFn("hello world"),
+				method("uuid_v5"),
+			),
+			output: "191333f6-c83e-5b3b-bdb0-bd483ad1bcb7",
+		},
+		"check uuid_v5 not valid ns": {
+			input: methods(
+				literalFn("hello world"),
+				method("uuid_v5", "not valid"),
+			),
+			err: `string literal: invalid ns uuid: "not valid"`,
+		},
 		"check hex encode": {
 			input: methods(
 				literalFn("hello world"),


### PR DESCRIPTION
Hi,

Added bloblang string method `uuid_v5` to generate SHA1 uuids.

Examples:

```
root.id = "example".uuid_v5() # 00000000-0000-0000-0000-000000000000 used
# {"id": "feb54431-301b-52bb-a6dd-e1e93e81bb9e"}
root.id = "example".uuid_v5("x500") # predefined namespace
# {"id": "0cbd148f-768f-52fe-a1cd-0c4e6c65de91"}
root.id = "example".uuid_v5("77f836b7-9f61-46c0-851e-9b6ca3535e69")
# {"id": "a0d220eb-18f1-50ca-b888-86aa5b604edf"}
```

Fix: redpanda-data/connect/issues/2484