### PR TITLE
Support multi-value HTTP headers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ All notable changes to this project will be documented in this file.
 - Field `client_auth` added to the `socket_server` input. (@filippog)
 - New Bloblang string method `uuid_v5`. (@artemklevtsov)
 
+### Changed
+
+- The `http_client` input and output and the `http` processor now support extracting multi-value HTTP headers. (@mihaitodor)
+
 ## 4.47.0 - 2025-04-03
 
 ### Added

--- a/internal/httpclient/client.go
+++ b/internal/httpclient/client.go
@@ -221,7 +221,15 @@ func (h *Client) ResponseToBatch(res *http.Response) (service.MessageBatch, erro
 			for k, values := range res.Header {
 				normalisedHeader := strings.ToLower(k)
 				if len(values) > 0 && h.metaExtractFilter.Match(normalisedHeader) {
-					p.MetaSetMut(normalisedHeader, values[0])
+					if len(values) == 1 {
+						p.MetaSetMut(normalisedHeader, values[0])
+					} else {
+						metaVal := make([]any, 0, len(values))
+						for _, v := range values {
+							metaVal = append(metaVal, v)
+						}
+						p.MetaSetMut(normalisedHeader, metaVal)
+					}
 				}
 			}
 		}


### PR DESCRIPTION
Enable multi-value HTTP header support for the `http_client` input and output and for the `http` processor.

Fixes https://github.com/redpanda-data/connect/issues/1389.

PS: Technically, this is a small breaking change, but I think it's better to do it and maybe introduce a flag to toggle the old behaviour if it ends up preventing users from upgrading.