### PR TITLE
Add open_message_mapping to socket input

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ All notable changes to this project will be documented in this file.
 - CLI flag `--env-file` added to the `blobl` command. (@mihaitodor)
 - Go API: New `ComponentLinter` APIs for linting general component configs. (@Jeffail)
 - New `bitwise_and`, `bitwise_or`, and `bitwise_xor` bloblang methods. (@eadwright)
+- Field `open_message_mapping` added to the `socket` input. (@eadwright)
 
 ### Fixed
 

--- a/internal/impl/io/input_socket_test.go
+++ b/internal/impl/io/input_socket_test.go
@@ -213,6 +213,103 @@ socket:
 	conn.Close()
 }
 
+func TestSocketInputOpenMessage(t *testing.T) {
+	ctx, done := context.WithTimeout(t.Context(), time.Second*20)
+	defer done()
+
+	tmpDir := t.TempDir()
+
+	ln, err := net.Listen("unix", filepath.Join(tmpDir, "benthos.sock"))
+	if err != nil {
+		t.Fatalf("failed to listen on a address: %v", err)
+	}
+	defer ln.Close()
+
+	rdr := inputFromConf(t, `
+socket:
+  network: %v
+  address: %v
+  open_message_mapping: root = (1 + 2).string() + "\n"
+`, ln.Addr().Network(), ln.Addr().String())
+
+	defer func() {
+		rdr.TriggerStopConsuming()
+		if err := rdr.WaitForClose(ctx); err != nil {
+			t.Error(err)
+		}
+	}()
+
+	conn, err := ln.Accept()
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	reader := bufio.NewReader(conn)
+	line, err := reader.ReadString('\n')
+	if err != nil {
+		t.Fatal(err)
+	}
+	if line != "3\n" {
+		t.Fatalf("Expected 3, got %s", line)
+	}
+
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+	go func() {
+		_ = conn.SetWriteDeadline(time.Now().Add(time.Second * 5))
+		if _, cerr := conn.Write([]byte("foo\n")); cerr != nil {
+			t.Error(cerr)
+		}
+		if _, cerr := conn.Write([]byte("bar\n")); cerr != nil {
+			t.Error(cerr)
+		}
+		if _, cerr := conn.Write([]byte("baz\n")); cerr != nil {
+			t.Error(cerr)
+		}
+		wg.Done()
+	}()
+
+	readNextMsg := func() (message.Batch, error) {
+		var msg message.Batch
+		select {
+		case tran := <-rdr.TransactionChan():
+			msg = tran.Payload.DeepCopy()
+			require.NoError(t, tran.Ack(ctx, nil))
+		case <-time.After(time.Second):
+			return nil, errors.New("timed out")
+		}
+		return msg, nil
+	}
+
+	exp := [][]byte{[]byte("foo")}
+	msg, err := readNextMsg()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if act := message.GetAllBytes(msg); !reflect.DeepEqual(exp, act) {
+		t.Errorf("Wrong message contents: %s != %s", act, exp)
+	}
+
+	exp = [][]byte{[]byte("bar")}
+	if msg, err = readNextMsg(); err != nil {
+		t.Fatal(err)
+	}
+	if act := message.GetAllBytes(msg); !reflect.DeepEqual(exp, act) {
+		t.Errorf("Wrong message contents: %s != %s", act, exp)
+	}
+
+	exp = [][]byte{[]byte("baz")}
+	if msg, err = readNextMsg(); err != nil {
+		t.Fatal(err)
+	}
+	if act := message.GetAllBytes(msg); !reflect.DeepEqual(exp, act) {
+		t.Errorf("Wrong message contents: %s != %s", act, exp)
+	}
+
+	wg.Wait()
+	conn.Close()
+}
+
 func TestSocketInputMultipart(t *testing.T) {
 	ctx, done := context.WithTimeout(t.Context(), time.Second*20)
 	defer done()
@@ -1017,103 +1114,6 @@ socket:
 		act, err := readNextMsg()
 		assert.NoError(b, err)
 		assert.Equal(b, exp, act)
-	}
-
-	wg.Wait()
-	conn.Close()
-}
-
-func TestSocketOpenMessage(t *testing.T) {
-	ctx, done := context.WithTimeout(t.Context(), time.Second*20)
-	defer done()
-
-	tmpDir := t.TempDir()
-
-	ln, err := net.Listen("unix", filepath.Join(tmpDir, "benthos.sock"))
-	if err != nil {
-		t.Fatalf("failed to listen on a address: %v", err)
-	}
-	defer ln.Close()
-
-	rdr := inputFromConf(t, `
-socket:
-  network: %v
-  address: %v
-  open_message_mapping: root = (1 + 2).string() + "\n"
-`, ln.Addr().Network(), ln.Addr().String())
-
-	defer func() {
-		rdr.TriggerStopConsuming()
-		if err := rdr.WaitForClose(ctx); err != nil {
-			t.Error(err)
-		}
-	}()
-
-	conn, err := ln.Accept()
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	reader := bufio.NewReader(conn)
-	line, err := reader.ReadString('\n')
-	if err != nil {
-		t.Fatal(err)
-	}
-	if line != "3\n" {
-		t.Fatalf("Expected 3, got %s", line)
-	}
-
-	wg := sync.WaitGroup{}
-	wg.Add(1)
-	go func() {
-		_ = conn.SetWriteDeadline(time.Now().Add(time.Second * 5))
-		if _, cerr := conn.Write([]byte("foo\n")); cerr != nil {
-			t.Error(cerr)
-		}
-		if _, cerr := conn.Write([]byte("bar\n")); cerr != nil {
-			t.Error(cerr)
-		}
-		if _, cerr := conn.Write([]byte("baz\n")); cerr != nil {
-			t.Error(cerr)
-		}
-		wg.Done()
-	}()
-
-	readNextMsg := func() (message.Batch, error) {
-		var msg message.Batch
-		select {
-		case tran := <-rdr.TransactionChan():
-			msg = tran.Payload.DeepCopy()
-			require.NoError(t, tran.Ack(ctx, nil))
-		case <-time.After(time.Second):
-			return nil, errors.New("timed out")
-		}
-		return msg, nil
-	}
-
-	exp := [][]byte{[]byte("foo")}
-	msg, err := readNextMsg()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if act := message.GetAllBytes(msg); !reflect.DeepEqual(exp, act) {
-		t.Errorf("Wrong message contents: %s != %s", act, exp)
-	}
-
-	exp = [][]byte{[]byte("bar")}
-	if msg, err = readNextMsg(); err != nil {
-		t.Fatal(err)
-	}
-	if act := message.GetAllBytes(msg); !reflect.DeepEqual(exp, act) {
-		t.Errorf("Wrong message contents: %s != %s", act, exp)
-	}
-
-	exp = [][]byte{[]byte("baz")}
-	if msg, err = readNextMsg(); err != nil {
-		t.Fatal(err)
-	}
-	if act := message.GetAllBytes(msg); !reflect.DeepEqual(exp, act) {
-		t.Errorf("Wrong message contents: %s != %s", act, exp)
 	}
 
 	wg.Wait()


### PR DESCRIPTION
Add optional `open_message_mapping` to `socket`, so we can send the result of a Bloblang mapping as an open message when making a connection.

This allows dynamic messages to be supported, such as time-dependent ones.

Contrived example:

```
input:
  label: conn
  socket:
    network: tcp
    address: 127.0.0.1:12345
    open_message_mapping: root = (1 + 2).string() + "\n"
```

This sends `3\n` upstream.

The message being sent (typically for authentication) is not based on input, and is sent before any input is received. The Bloblang is called every time the socket connects or reconnects.