### PR TITLE
Add bitwise and/or/xor support for integers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 
 - CLI flag `--env-file` added to the `blobl` command. (@mihaitodor)
 - Go API: New `ComponentLinter` APIs for linting general component configs. (@Jeffail)
+- New `bitwise_and`, `bitwise_or`, and `bitwise_xor` bloblang methods. (@eadwright)
 
 ### Fixed
 

--- a/internal/bloblang/query/methods_numbers.go
+++ b/internal/bloblang/query/methods_numbers.go
@@ -246,8 +246,10 @@ var _ = registerSimpleMethod(
 			`root.new_value = this.value.bitwise_and(6)`,
 			`{"value":12}`,
 			`{"new_value":4}`,
-			`{"value":14}`,
-			`{"new_value":6}`,
+			`{"value":0}`,
+			`{"new_value":0}`,
+			`{"value":-4}`,
+			`{"new_value":4}`,
 		),
 	).Param(ParamInt64("value", "The value to AND with")),
 	func(args *ParsedParams) (simpleMethod, error) {
@@ -256,7 +258,7 @@ var _ = registerSimpleMethod(
 			return nil, err
 		}
 
-		return func(v any, ctx FunctionContext) (any, error) {
+		return func(v any, _ FunctionContext) (any, error) {
 			lhs, err := value.IGetInt(v)
 			if err != nil {
 				return nil, value.NewTypeError(v, value.TInt)
@@ -277,8 +279,10 @@ var _ = registerSimpleMethod(
 			`root.new_value = this.value.bitwise_or(6)`,
 			`{"value":12}`,
 			`{"new_value":14}`,
-			`{"value":14}`,
-			`{"new_value":14}`,
+			`{"value":0}`,
+			`{"new_value":6}`,
+			`{"value":-2}`,
+			`{"new_value":-2}`,
 		),
 	).Param(ParamInt64("value", "The value to OR with")),
 	func(args *ParsedParams) (simpleMethod, error) {
@@ -287,7 +291,7 @@ var _ = registerSimpleMethod(
 			return nil, err
 		}
 
-		return func(v any, ctx FunctionContext) (any, error) {
+		return func(v any, _ FunctionContext) (any, error) {
 			lhs, err := value.IGetInt(v)
 			if err != nil {
 				return nil, value.NewTypeError(v, value.TInt)
@@ -308,8 +312,10 @@ var _ = registerSimpleMethod(
 			`root.new_value = this.value.bitwise_xor(6)`,
 			`{"value":12}`,
 			`{"new_value":10}`,
-			`{"value":6}`,
-			`{"new_value":0}`,
+			`{"value":0}`,
+			`{"new_value":6}`,
+			`{"value":-2}`,
+			`{"new_value":-8}`,
 		),
 	).Param(ParamInt64("value", "The value to XOR with")),
 	func(args *ParsedParams) (simpleMethod, error) {
@@ -318,7 +324,7 @@ var _ = registerSimpleMethod(
 			return nil, err
 		}
 
-		return func(v any, ctx FunctionContext) (any, error) {
+		return func(v any, _ FunctionContext) (any, error) {
 			lhs, err := value.IGetInt(v)
 			if err != nil {
 				return nil, value.NewTypeError(v, value.TInt)

--- a/internal/bloblang/query/methods_numbers.go
+++ b/internal/bloblang/query/methods_numbers.go
@@ -235,3 +235,96 @@ var _ = registerSimpleMethod(
 		}), nil
 	},
 )
+
+var _ = registerSimpleMethod(
+	NewMethodSpec(
+		"bitwise_and", "Returns the number bitwise AND-ed with the specified value.",
+	).InCategory(
+		MethodCategoryNumbers,
+		"",
+		NewExampleSpec("",
+			`root.new_value = this.value.bitwise_and(6)`,
+			`{"value":12}`,
+			`{"new_value":4}`,
+			`{"value":14}`,
+			`{"new_value":6}`,
+		),
+	).Param(ParamInt64("value", "The value to AND with")),
+	func(args *ParsedParams) (simpleMethod, error) {
+		rhs, err := args.FieldInt64("value")
+		if err != nil {
+			return nil, err
+		}
+
+		return func(v any, ctx FunctionContext) (any, error) {
+			lhs, err := value.IGetInt(v)
+			if err != nil {
+				return nil, value.NewTypeError(v, value.TInt)
+			}
+
+			return lhs & rhs, nil
+		}, nil
+	},
+)
+
+var _ = registerSimpleMethod(
+	NewMethodSpec(
+		"bitwise_or", "Returns the number bitwise OR-ed with the specified value.",
+	).InCategory(
+		MethodCategoryNumbers,
+		"",
+		NewExampleSpec("",
+			`root.new_value = this.value.bitwise_or(6)`,
+			`{"value":12}`,
+			`{"new_value":14}`,
+			`{"value":14}`,
+			`{"new_value":14}`,
+		),
+	).Param(ParamInt64("value", "The value to OR with")),
+	func(args *ParsedParams) (simpleMethod, error) {
+		rhs, err := args.FieldInt64("value")
+		if err != nil {
+			return nil, err
+		}
+
+		return func(v any, ctx FunctionContext) (any, error) {
+			lhs, err := value.IGetInt(v)
+			if err != nil {
+				return nil, value.NewTypeError(v, value.TInt)
+			}
+
+			return lhs | rhs, nil
+		}, nil
+	},
+)
+
+var _ = registerSimpleMethod(
+	NewMethodSpec(
+		"bitwise_xor", "Returns the number bitwise eXclusive-OR-ed with the specified value.",
+	).InCategory(
+		MethodCategoryNumbers,
+		"",
+		NewExampleSpec("",
+			`root.new_value = this.value.bitwise_xor(6)`,
+			`{"value":12}`,
+			`{"new_value":10}`,
+			`{"value":6}`,
+			`{"new_value":0}`,
+		),
+	).Param(ParamInt64("value", "The value to XOR with")),
+	func(args *ParsedParams) (simpleMethod, error) {
+		rhs, err := args.FieldInt64("value")
+		if err != nil {
+			return nil, err
+		}
+
+		return func(v any, ctx FunctionContext) (any, error) {
+			lhs, err := value.IGetInt(v)
+			if err != nil {
+				return nil, value.NewTypeError(v, value.TInt)
+			}
+
+			return lhs ^ rhs, nil
+		}, nil
+	},
+)

--- a/internal/impl/pure/bloblang_numbers.go
+++ b/internal/impl/pure/bloblang_numbers.go
@@ -230,66 +230,6 @@ root.outs = this.ins.map_each(ele -> ele.abs())
 			}), nil
 		})
 
-	bloblang.MustRegisterMethodV2("bitwise_and",
-		bloblang.NewPluginSpec().
-			Category(query.MethodCategoryNumbers).
-			Description(`Returns the number bitwise AND-ed with the specified value.`).
-			Example("", `root.new_value = this.value.bitwise_and(6)`,
-				[2]string{`{"value":12}`, `{"new_value":4}`}).
-			Example("", `root.new_value = this.value.bitwise_and(3)`,
-				[2]string{`{"value":14}`, `{"new_value":2}`}).
-			Param(bloblang.NewInt64Param("value").
-				Description("The value you wish to AND with.")),
-		func(args *bloblang.ParsedParams) (bloblang.Method, error) {
-			return bloblang.Int64Method(func(input int64) (any, error) {
-				value, err := args.GetInt64("value")
-				if err != nil {
-					return nil, err
-				}
-				return input & value, nil
-			}), nil
-		})
-
-	bloblang.MustRegisterMethodV2("bitwise_or",
-		bloblang.NewPluginSpec().
-			Category(query.MethodCategoryNumbers).
-			Description(`Returns the number bitwise OR-ed with the specified value.`).
-			Example("", `root.new_value = this.value.bitwise_or(6)`,
-				[2]string{`{"value":12}`, `{"new_value":14}`}).
-			Example("", `root.new_value = this.value.bitwise_or(3)`,
-				[2]string{`{"value":14}`, `{"new_value":15}`}).
-			Param(bloblang.NewInt64Param("value").
-				Description("The value you wish to OR with.")),
-		func(args *bloblang.ParsedParams) (bloblang.Method, error) {
-			return bloblang.Int64Method(func(input int64) (any, error) {
-				value, err := args.GetInt64("value")
-				if err != nil {
-					return nil, err
-				}
-				return input | value, nil
-			}), nil
-		})
-
-	bloblang.MustRegisterMethodV2("bitwise_xor",
-		bloblang.NewPluginSpec().
-			Category(query.MethodCategoryNumbers).
-			Description(`Returns the number bitwise XOR-ed with the specified value.`).
-			Example("", `root.new_value = this.value.bitwise_xor(6)`,
-				[2]string{`{"value":12}`, `{"new_value":10}`}).
-			Example("", `root.new_value = this.value.bitwise_xor(3)`,
-				[2]string{`{"value":14}`, `{"new_value":13}`}).
-			Param(bloblang.NewInt64Param("value").
-				Description("The value you wish to XOR with.")),
-		func(args *bloblang.ParsedParams) (bloblang.Method, error) {
-			return bloblang.Int64Method(func(input int64) (any, error) {
-				value, err := args.GetInt64("value")
-				if err != nil {
-					return nil, err
-				}
-				return input ^ value, nil
-			}), nil
-		})
-
 	//------------------------------------------------------------------------------
 
 	bloblang.MustRegisterFunctionV2("pi",

--- a/internal/impl/pure/bloblang_numbers.go
+++ b/internal/impl/pure/bloblang_numbers.go
@@ -230,6 +230,66 @@ root.outs = this.ins.map_each(ele -> ele.abs())
 			}), nil
 		})
 
+	bloblang.MustRegisterMethodV2("bitwise_and",
+		bloblang.NewPluginSpec().
+			Category(query.MethodCategoryNumbers).
+			Description(`Returns the number bitwise AND-ed with the specified value.`).
+			Example("", `root.new_value = this.value.bitwise_and(6)`,
+				[2]string{`{"value":12}`, `{"new_value":4}`}).
+			Example("", `root.new_value = this.value.bitwise_and(3)`,
+				[2]string{`{"value":14}`, `{"new_value":2}`}).
+			Param(bloblang.NewInt64Param("value").
+				Description("The value you wish to AND with.")),
+		func(args *bloblang.ParsedParams) (bloblang.Method, error) {
+			return bloblang.Int64Method(func(input int64) (any, error) {
+				value, err := args.GetInt64("value")
+				if err != nil {
+					return nil, err
+				}
+				return input & value, nil
+			}), nil
+		})
+
+	bloblang.MustRegisterMethodV2("bitwise_or",
+		bloblang.NewPluginSpec().
+			Category(query.MethodCategoryNumbers).
+			Description(`Returns the number bitwise OR-ed with the specified value.`).
+			Example("", `root.new_value = this.value.bitwise_or(6)`,
+				[2]string{`{"value":12}`, `{"new_value":14}`}).
+			Example("", `root.new_value = this.value.bitwise_or(3)`,
+				[2]string{`{"value":14}`, `{"new_value":15}`}).
+			Param(bloblang.NewInt64Param("value").
+				Description("The value you wish to OR with.")),
+		func(args *bloblang.ParsedParams) (bloblang.Method, error) {
+			return bloblang.Int64Method(func(input int64) (any, error) {
+				value, err := args.GetInt64("value")
+				if err != nil {
+					return nil, err
+				}
+				return input | value, nil
+			}), nil
+		})
+
+	bloblang.MustRegisterMethodV2("bitwise_xor",
+		bloblang.NewPluginSpec().
+			Category(query.MethodCategoryNumbers).
+			Description(`Returns the number bitwise XOR-ed with the specified value.`).
+			Example("", `root.new_value = this.value.bitwise_xor(6)`,
+				[2]string{`{"value":12}`, `{"new_value":10}`}).
+			Example("", `root.new_value = this.value.bitwise_xor(3)`,
+				[2]string{`{"value":14}`, `{"new_value":13}`}).
+			Param(bloblang.NewInt64Param("value").
+				Description("The value you wish to XOR with.")),
+		func(args *bloblang.ParsedParams) (bloblang.Method, error) {
+			return bloblang.Int64Method(func(input int64) (any, error) {
+				value, err := args.GetInt64("value")
+				if err != nil {
+					return nil, err
+				}
+				return input ^ value, nil
+			}), nil
+		})
+
 	//------------------------------------------------------------------------------
 
 	bloblang.MustRegisterFunctionV2("pi",


### PR DESCRIPTION
Adds methods `bitwise_and()`, `bitwise_or()` and `bitwise_xor()` which work on integers and do what you expect.

The prefix is due to the name collision with `or`. Through the magic of the existing code structure, we have tests.