### PR TITLE
Fix env var loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ Changelog
 
 All notable changes to this project will be documented in this file.
 
+## 4.52.0 - TBD
+
+### Fixed
+
+- Fixed a regression bug where the `echo` and `lint` commands no longer loaded environment variables. (@mihaitodor)
+
 ## 4.51.0 - 2025-05-15
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 
 ## 4.52.0 - TBD
 
+### Added
+
+- CLI flag `--env-file` added to the `blobl` command. (@mihaitodor)
+
 ### Fixed
 
 - Fixed a regression bug where the `echo` and `lint` commands no longer loaded environment variables. (@mihaitodor)

--- a/internal/cli/echo.go
+++ b/internal/cli/echo.go
@@ -39,12 +39,16 @@ variables have been resolved:
 
   {{.BinaryName}} echo ./config.yaml | less
   {{.BinaryName}} echo --set 'input.generate.mapping=root.id = uuid_v4()'
-  
+
   `)[1:],
 		Before: func(c *cli.Context) error {
 			return common.PreApplyEnvFilesAndTemplates(c, opts)
 		},
 		Action: func(c *cli.Context) error {
+			if err := opts.CustomRunExtractFn(c); err != nil {
+				return err
+			}
+
 			if c.Args().Len() > 0 {
 				if c.Args().Len() > 1 {
 					return errors.New("a maximum of one config must be specified with the echo command")

--- a/internal/cli/lint.go
+++ b/internal/cli/lint.go
@@ -196,6 +196,10 @@ func lintMDSnippets(path string, spec docs.FieldSpecs, lConf docs.LintConfig) (p
 // LintAction performs the benthos lint subcommand and returns the appropriate
 // exit code. This function is exported for testing purposes only.
 func LintAction(c *cli.Context, opts *common.CLIOpts, stderr io.Writer) error {
+	if err := opts.CustomRunExtractFn(c); err != nil {
+		return err
+	}
+
 	targets, err := ifilepath.GlobsAndSuperPaths(ifs.OS(), c.Args().Slice(), "yaml", "yml")
 	if err != nil {
 		return fmt.Errorf("lint paths error: %w", err)


### PR DESCRIPTION
This fixes a regression introduced in v4.40.0 (commit https://github.com/redpanda-data/benthos/commit/48e6c4f412737e9b76bd2eab7af8630efb037d3d).

Also add the `--env-file` flag to the blobl command.

Fixes #223.
Fixes #195.
Fixes #149.