### PR TITLE
fix: input sequence hanging when input fails

### DIFF
--- a/internal/impl/pure/input_sequence.go
+++ b/internal/impl/pure/input_sequence.go
@@ -450,6 +450,7 @@ func (r *sequenceInput) createNextTarget() (input.Streamed, bool, error) {
 	var err error
 
 	r.targetMut.Lock()
+	defer r.targetMut.Unlock()
 	r.target = nil
 	if len(r.remaining) > 0 {
 		next := r.remaining[0]
@@ -466,7 +467,6 @@ func (r *sequenceInput) createNextTarget() (input.Streamed, bool, error) {
 		r.target = target
 	}
 	final := len(r.remaining) == 0
-	r.targetMut.Unlock()
 
 	return target, final, err
 }


### PR DESCRIPTION
Currently sequence input is entering a deadlock when one of the inputs fail because the lock is never released.

Note: I found the same issue on several places in the code. It might be useful to do a big review