### PR TITLE
Add common schemas package

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 - Added TLS support to the input and output `socket` components. (@eadwright)
- 
+- Go API: New `public/schema` package for serde to and from a common schema format. (@Jeffail)
+- New Bloblang method `infer_schema`. (@Jeffail)
+
 ## 4.53.1 - 2025-07-08
 
 ### Fixed

--- a/internal/impl/pure/bloblang_schema.go
+++ b/internal/impl/pure/bloblang_schema.go
@@ -1,0 +1,25 @@
+// Copyright 2025 Redpanda Data, Inc.
+
+package pure
+
+import (
+	"github.com/redpanda-data/benthos/v4/internal/bloblang/query"
+	"github.com/redpanda-data/benthos/v4/public/bloblang"
+	"github.com/redpanda-data/benthos/v4/public/schema"
+)
+
+func init() {
+	bloblang.MustRegisterMethodV2("infer_schema",
+		bloblang.NewPluginSpec().
+			Category(query.MethodCategoryParsing).
+			Description("Attempt to infer the schema of a given value. The resulting schema can then be used as an input to schema conversion and enforcement methods."),
+		func(args *bloblang.ParsedParams) (bloblang.Method, error) {
+			return func(v any) (any, error) {
+				s, err := schema.InferFromAny(v)
+				if err != nil {
+					return nil, err
+				}
+				return s.ToAny(), nil
+			}, nil
+		})
+}

--- a/public/schema/common.go
+++ b/public/schema/common.go
@@ -25,6 +25,7 @@ const (
 	Array     CommonType = 10
 	Null      CommonType = 11
 	Union     CommonType = 12
+	Timestamp CommonType = 13
 )
 
 // String returns a human readable string representation of the type.
@@ -54,6 +55,8 @@ func (t CommonType) String() string {
 		return "NULL"
 	case Union:
 		return "UNION"
+	case Timestamp:
+		return "TIMESTAMP"
 	default:
 		return "UNKNOWN"
 	}
@@ -85,6 +88,8 @@ func typeFromStr(v string) (CommonType, error) {
 		return Null, nil
 	case "UNION":
 		return Union, nil
+	case "TIMESTAMP":
+		return Timestamp, nil
 	default:
 		return 0, fmt.Errorf("unrecognised type string: %v", v)
 	}

--- a/public/schema/common.go
+++ b/public/schema/common.go
@@ -101,6 +101,13 @@ type Common struct {
 	Children []Common
 }
 
+const (
+	anyFieldType     = "type"
+	anyFieldName     = "name"
+	anyFieldOptional = "optional"
+	anyFieldChildren = "children"
+)
+
 // ToAny serializes the common schema into a generic Go value, with structured
 // schemas being represented as map[string]any and []any. This could be further
 // manipulated using generic mapping tools such as bloblang, before either
@@ -113,15 +120,15 @@ type Common struct {
 // the Children field.
 func (c *Common) ToAny() any {
 	m := map[string]any{
-		"type": c.Type.String(),
+		anyFieldType: c.Type.String(),
 	}
 
 	if c.Name != "" {
-		m["name"] = c.Name
+		m[anyFieldName] = c.Name
 	}
 
 	if c.Optional {
-		m["optional"] = true
+		m[anyFieldOptional] = true
 	}
 
 	if len(c.Children) > 0 {
@@ -129,7 +136,7 @@ func (c *Common) ToAny() any {
 		for i, child := range c.Children {
 			children[i] = child.ToAny()
 		}
-		m["children"] = children
+		m[anyFieldChildren] = children
 	}
 
 	return m
@@ -144,32 +151,32 @@ func ParseFromAny(v any) (Common, error) {
 		return c, fmt.Errorf("expected map, received: %T", v)
 	}
 
-	if typeStr, ok := obj["type"].(string); ok {
+	if typeStr, ok := obj[anyFieldType].(string); ok {
 		var err error
 		if c.Type, err = typeFromStr(typeStr); err != nil {
 			return c, err
 		}
 	} else {
-		return c, fmt.Errorf("expected field `type` of type string, got %T", obj["type"])
+		return c, fmt.Errorf("expected field `type` of type string, got %T", obj[anyFieldType])
 	}
 
-	if name, ok := obj["name"]; ok {
+	if name, ok := obj[anyFieldName]; ok {
 		if nameStr, ok := name.(string); ok {
 			c.Name = nameStr
 		} else {
-			return c, fmt.Errorf("expected field `name` of type string, got %T", obj["name"])
+			return c, fmt.Errorf("expected field `name` of type string, got %T", obj[anyFieldName])
 		}
 	}
 
-	if optional, ok := obj["optional"]; ok {
+	if optional, ok := obj[anyFieldOptional]; ok {
 		if optionalB, ok := optional.(bool); ok {
 			c.Optional = optionalB
 		} else {
-			return c, fmt.Errorf("expected field `optional` of type string, got %T", obj["optional"])
+			return c, fmt.Errorf("expected field `optional` of type string, got %T", obj[anyFieldOptional])
 		}
 	}
 
-	if cArr, ok := obj["children"].([]any); ok {
+	if cArr, ok := obj[anyFieldChildren].([]any); ok {
 		for i, cEle := range cArr {
 			cChild, err := ParseFromAny(cEle)
 			if err != nil {

--- a/public/schema/common.go
+++ b/public/schema/common.go
@@ -13,19 +13,18 @@ type CommonType int
 
 // Supported common types
 const (
-	Boolean           CommonType = 0
-	Int32             CommonType = 1
-	Int64             CommonType = 2
-	Float32           CommonType = 3
-	Float64           CommonType = 4
-	String            CommonType = 5
-	ByteArray         CommonType = 6
-	FixedLenByteArray CommonType = 7
-	Object            CommonType = 8
-	Map               CommonType = 9
-	Array             CommonType = 10
-	Null              CommonType = 11
-	Union             CommonType = 12
+	Boolean   CommonType = 0
+	Int32     CommonType = 1
+	Int64     CommonType = 2
+	Float32   CommonType = 3
+	Float64   CommonType = 4
+	String    CommonType = 5
+	ByteArray CommonType = 6
+	Object    CommonType = 7
+	Map       CommonType = 8
+	Array     CommonType = 9
+	Null      CommonType = 10
+	Union     CommonType = 11
 )
 
 // String returns a human readable string representation of the type.
@@ -45,8 +44,6 @@ func (t CommonType) String() string {
 		return "STRING"
 	case ByteArray:
 		return "BYTE_ARRAY"
-	case FixedLenByteArray:
-		return "FIXED_LEN_BYTE_ARRAY"
 	case Object:
 		return "OBJECT"
 	case Map:
@@ -78,8 +75,6 @@ func typeFromStr(v string) (CommonType, error) {
 		return String, nil
 	case "BYTE_ARRAY":
 		return ByteArray, nil
-	case "FIXED_LEN_BYTE_ARRAY":
-		return FixedLenByteArray, nil
 	case "OBJECT":
 		return Object, nil
 	case "MAP":

--- a/public/schema/common.go
+++ b/public/schema/common.go
@@ -1,0 +1,189 @@
+// Copyright 2025 Redpanda Data, Inc.
+
+// Package schema implements a common standard for describing data schemas
+// within the domain of benthos. The intention for these schemas is to encourage
+// schema conversion between multiple common formats such as avro, parquet, and
+// so on.
+package schema
+
+import "fmt"
+
+// CommonType represents types supported by common schemas.
+type CommonType int
+
+// Supported common types
+const (
+	Boolean           CommonType = 0
+	Int32             CommonType = 1
+	Int64             CommonType = 2
+	Float32           CommonType = 3
+	Float64           CommonType = 4
+	String            CommonType = 5
+	ByteArray         CommonType = 6
+	FixedLenByteArray CommonType = 7
+	Object            CommonType = 8
+	Map               CommonType = 9
+	Array             CommonType = 10
+	Null              CommonType = 11
+	Union             CommonType = 12
+)
+
+// String returns a human readable string representation of the type.
+func (t CommonType) String() string {
+	switch t {
+	case Boolean:
+		return "BOOLEAN"
+	case Int32:
+		return "INT32"
+	case Int64:
+		return "INT64"
+	case Float32:
+		return "FLOAT32"
+	case Float64:
+		return "FLOAT64"
+	case String:
+		return "STRING"
+	case ByteArray:
+		return "BYTE_ARRAY"
+	case FixedLenByteArray:
+		return "FIXED_LEN_BYTE_ARRAY"
+	case Object:
+		return "OBJECT"
+	case Map:
+		return "MAP"
+	case Array:
+		return "ARRAY"
+	case Null:
+		return "NULL"
+	case Union:
+		return "UNION"
+	default:
+		return "Type(?)"
+	}
+}
+
+func typeFromStr(v string) (CommonType, error) {
+	switch v {
+	case "BOOLEAN":
+		return Boolean, nil
+	case "INT32":
+		return Int32, nil
+	case "INT64":
+		return Int64, nil
+	case "FLOAT32":
+		return Float32, nil
+	case "FLOAT64":
+		return Float64, nil
+	case "STRING":
+		return String, nil
+	case "BYTE_ARRAY":
+		return ByteArray, nil
+	case "FIXED_LEN_BYTE_ARRAY":
+		return FixedLenByteArray, nil
+	case "OBJECT":
+		return Object, nil
+	case "MAP":
+		return Map, nil
+	case "ARRAY":
+		return Array, nil
+	case "NULL":
+		return Null, nil
+	case "UNION":
+		return Union, nil
+	default:
+		return 0, fmt.Errorf("unrecognised type string: %v", v)
+	}
+}
+
+// Common schema is a neutral form that can be converted to and from other
+// schemas. This is not intended to be a superset of all schema capabilites and
+// instead focuses on compatibility and minimum viable translations between
+// schemas.
+type Common struct {
+	Name     string
+	Type     CommonType
+	Optional bool
+	Children []*Common
+}
+
+// ToAny serializes the common schema into a generic Go value, with structured
+// schemas being represented as map[string]any and []any. This could be further
+// manipulated using generic mapping tools such as bloblang, before either
+// bringing back into a Common representation or serializing into another
+// format.
+//
+// NOTE: Ironically, the schema for this serialization is not something that can
+// actually be represented as a Common schema. This is because we do not support
+// schemas that nest complex types, which would be necessary for representing
+// the Children field.
+func (c *Common) ToAny() any {
+	m := map[string]any{
+		"type": c.Type.String(),
+	}
+
+	if c.Name != "" {
+		m["name"] = c.Name
+	}
+
+	if c.Optional {
+		m["optional"] = true
+	}
+
+	if len(c.Children) > 0 {
+		children := make([]any, len(c.Children))
+		for i, child := range c.Children {
+			children[i] = child.ToAny()
+		}
+		m["children"] = children
+	}
+
+	return m
+}
+
+// ParseFromAny deserializes a common schema from a generic Go value.
+func ParseFromAny(v any) (*Common, error) {
+	obj, ok := v.(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("expected map, received: %T", v)
+	}
+
+	c := &Common{}
+
+	if typeStr, ok := obj["type"].(string); ok {
+		var err error
+		if c.Type, err = typeFromStr(typeStr); err != nil {
+			return nil, err
+		}
+	} else {
+		return nil, fmt.Errorf("expected field `type` of type string, got %T", obj["type"])
+	}
+
+	if name, ok := obj["name"]; ok {
+		if nameStr, ok := name.(string); ok {
+			c.Name = nameStr
+		} else {
+			return nil, fmt.Errorf("expected field `name` of type string, got %T", obj["name"])
+		}
+	}
+
+	if optional, ok := obj["optional"]; ok {
+		if optionalB, ok := optional.(bool); ok {
+			c.Optional = optionalB
+		} else {
+			return nil, fmt.Errorf("expected field `optional` of type string, got %T", obj["optional"])
+		}
+	}
+
+	if cArr, ok := obj["children"].([]any); ok {
+		for i, cEle := range cArr {
+			cChild, err := ParseFromAny(cEle)
+			if err != nil {
+				return nil, fmt.Errorf("child element %v: %w", i, err)
+			}
+
+			c.Children = append(c.Children, cChild)
+		}
+	}
+
+	return c, nil
+}

--- a/public/schema/common_test.go
+++ b/public/schema/common_test.go
@@ -1,0 +1,33 @@
+// Copyright 2025 Redpanda Data, Inc.
+
+package schema
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSchemaStringify(t *testing.T) {
+	for _, test := range []struct {
+		Input  CommonType
+		Output string
+	}{
+		{Input: Boolean, Output: "BOOLEAN"},
+		{Input: Int64, Output: "INT64"},
+		{Input: Int32, Output: "INT32"},
+		{Input: Float32, Output: "FLOAT32"},
+		{Input: Float64, Output: "FLOAT64"},
+		{Input: String, Output: "STRING"},
+		{Input: ByteArray, Output: "BYTE_ARRAY"},
+		{Input: FixedLenByteArray, Output: "FIXED_LEN_BYTE_ARRAY"},
+		{Input: Object, Output: "OBJECT"},
+		{Input: Map, Output: "MAP"},
+		{Input: Array, Output: "ARRAY"},
+		{Input: Null, Output: "NULL"},
+		{Input: Union, Output: "UNION"},
+		{Input: CommonType(-1), Output: "Type(?)"},
+	} {
+		assert.Equal(t, test.Input.String(), test.Output)
+	}
+}

--- a/public/schema/common_test.go
+++ b/public/schema/common_test.go
@@ -9,6 +9,8 @@ import (
 )
 
 func TestSchemaStringify(t *testing.T) {
+	var zeroType CommonType
+
 	for _, test := range []struct {
 		Input  CommonType
 		Output string
@@ -25,7 +27,8 @@ func TestSchemaStringify(t *testing.T) {
 		{Input: Array, Output: "ARRAY"},
 		{Input: Null, Output: "NULL"},
 		{Input: Union, Output: "UNION"},
-		{Input: CommonType(-1), Output: "Type(?)"},
+		{Input: zeroType, Output: "UNKNOWN"},
+		{Input: CommonType(-1), Output: "UNKNOWN"},
 	} {
 		assert.Equal(t, test.Input.String(), test.Output)
 	}

--- a/public/schema/common_test.go
+++ b/public/schema/common_test.go
@@ -20,7 +20,6 @@ func TestSchemaStringify(t *testing.T) {
 		{Input: Float64, Output: "FLOAT64"},
 		{Input: String, Output: "STRING"},
 		{Input: ByteArray, Output: "BYTE_ARRAY"},
-		{Input: FixedLenByteArray, Output: "FIXED_LEN_BYTE_ARRAY"},
 		{Input: Object, Output: "OBJECT"},
 		{Input: Map, Output: "MAP"},
 		{Input: Array, Output: "ARRAY"},

--- a/public/schema/common_test.go
+++ b/public/schema/common_test.go
@@ -27,6 +27,7 @@ func TestSchemaStringify(t *testing.T) {
 		{Input: Array, Output: "ARRAY"},
 		{Input: Null, Output: "NULL"},
 		{Input: Union, Output: "UNION"},
+		{Input: Timestamp, Output: "TIMESTAMP"},
 		{Input: zeroType, Output: "UNKNOWN"},
 		{Input: CommonType(-1), Output: "UNKNOWN"},
 	} {

--- a/public/schema/infer_from_any.go
+++ b/public/schema/infer_from_any.go
@@ -7,10 +7,8 @@ import (
 	"sort"
 )
 
-func inferFromAny(name string, v any) (*Common, error) {
-	c := Common{
-		Name: name,
-	}
+func inferFromAny(name string, v any) (Common, error) {
+	c := Common{Name: name}
 
 	switch t := v.(type) {
 	case bool:
@@ -32,12 +30,12 @@ func inferFromAny(name string, v any) (*Common, error) {
 		for i, e := range t {
 			ec, err := inferFromAny("", e)
 			if err != nil {
-				return nil, fmt.Errorf(".%v%v", i, err)
+				return c, fmt.Errorf(".%v%v", i, err)
 			}
 			if i == 0 {
-				c.Children = []*Common{ec}
+				c.Children = []Common{ec}
 			} else if c.Children[0].Type != ec.Type {
-				return nil, fmt.Errorf(".%v mismatched array types, found %v and %v", i, c.Children[0].Type, ec.Type)
+				return c, fmt.Errorf(".%v mismatched array types, found %v and %v", i, c.Children[0].Type, ec.Type)
 			}
 		}
 	case map[string]any:
@@ -54,17 +52,17 @@ func inferFromAny(name string, v any) (*Common, error) {
 
 			ec, err := inferFromAny(k, v)
 			if err != nil {
-				return nil, fmt.Errorf(".%v%v", k, err)
+				return c, fmt.Errorf(".%v%v", k, err)
 			}
 			c.Children = append(c.Children, ec)
 		}
 	case nil:
 		c.Type = Null
 	default:
-		return nil, fmt.Errorf(" unsupported data type: %T", v)
+		return c, fmt.Errorf(" unsupported data type: %T", v)
 	}
 
-	return &c, nil
+	return c, nil
 }
 
 // InferFromAny attempts to infer a common schema from any Go value. This
@@ -73,6 +71,6 @@ func inferFromAny(name string, v any) (*Common, error) {
 // float64, []byte, string, map[string]any, []any.
 //
 // All values will be recorded as non-optional.
-func InferFromAny(v any) (*Common, error) {
+func InferFromAny(v any) (Common, error) {
 	return inferFromAny("", v)
 }

--- a/public/schema/infer_from_any.go
+++ b/public/schema/infer_from_any.go
@@ -1,0 +1,78 @@
+// Copyright 2025 Redpanda Data, Inc.
+
+package schema
+
+import (
+	"fmt"
+	"sort"
+)
+
+func inferFromAny(name string, v any) (*Common, error) {
+	c := Common{
+		Name: name,
+	}
+
+	switch t := v.(type) {
+	case bool:
+		c.Type = Boolean
+	case int32:
+		c.Type = Int32
+	case int, int64:
+		c.Type = Int64
+	case float32:
+		c.Type = Float32
+	case float64:
+		c.Type = Float64
+	case []byte:
+		c.Type = ByteArray
+	case string:
+		c.Type = String
+	case []any:
+		c.Type = Array
+		for i, e := range t {
+			ec, err := inferFromAny("", e)
+			if err != nil {
+				return nil, fmt.Errorf(".%v%v", i, err)
+			}
+			if i == 0 {
+				c.Children = []*Common{ec}
+			} else if c.Children[0].Type != ec.Type {
+				return nil, fmt.Errorf(".%v mismatched array types, found %v and %v", i, c.Children[0].Type, ec.Type)
+			}
+		}
+	case map[string]any:
+		c.Type = Object
+
+		keys := make([]string, 0, len(t))
+		for k := range t {
+			keys = append(keys, k)
+		}
+		sort.Strings(keys)
+
+		for _, k := range keys {
+			v := t[k]
+
+			ec, err := inferFromAny(k, v)
+			if err != nil {
+				return nil, fmt.Errorf(".%v%v", k, err)
+			}
+			c.Children = append(c.Children, ec)
+		}
+	case nil:
+		c.Type = Null
+	default:
+		return nil, fmt.Errorf(" unsupported data type: %T", v)
+	}
+
+	return &c, nil
+}
+
+// InferFromAny attempts to infer a common schema from any Go value. This
+// process fails if the value, or any children of a provided map/slice, are not
+// within the following subset of Go types: bool, int, int32, int64, float32,
+// float64, []byte, string, map[string]any, []any.
+//
+// All values will be recorded as non-optional.
+func InferFromAny(v any) (*Common, error) {
+	return inferFromAny("", v)
+}

--- a/public/schema/infer_from_any.go
+++ b/public/schema/infer_from_any.go
@@ -5,6 +5,7 @@ package schema
 import (
 	"fmt"
 	"sort"
+	"time"
 )
 
 func inferFromAny(name string, v any) (Common, error) {
@@ -25,6 +26,8 @@ func inferFromAny(name string, v any) (Common, error) {
 		c.Type = ByteArray
 	case string:
 		c.Type = String
+	case time.Time:
+		c.Type = Timestamp
 	case []any:
 		c.Type = Array
 		for i, e := range t {

--- a/public/schema/infer_from_any_test.go
+++ b/public/schema/infer_from_any_test.go
@@ -1,0 +1,138 @@
+// Copyright 2025 Redpanda Data, Inc.
+
+package schema
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestFromAnySchema(t *testing.T) {
+	for _, test := range []struct {
+		Name        string
+		Input       any
+		Output      *Common
+		ErrContains string
+	}{
+		{
+			Name:  "Valid scalar schema",
+			Input: 10,
+			Output: &Common{
+				Type: Int64,
+			},
+		},
+		{
+			Name: "Valid flat object schema",
+			Input: map[string]any{
+				"foo":   "hello world",
+				"bar":   int32(11),
+				"baz":   float32(1.1),
+				"buz":   float64(1.2),
+				"moo":   true,
+				"quack": nil,
+			},
+			Output: &Common{
+				Type: Object,
+				Children: []*Common{
+					{Name: "bar", Type: Int32},
+					{Name: "baz", Type: Float32},
+					{Name: "buz", Type: Float64},
+					{Name: "foo", Type: String},
+					{Name: "moo", Type: Boolean},
+					{Name: "quack", Type: Null},
+				},
+			},
+		},
+		{
+			Name: "Valid nested object schema",
+			Input: map[string]any{
+				"foo": map[string]any{
+					"bar": []any{
+						[]any{
+							map[string]any{
+								"baz": []any{10},
+							},
+						},
+					},
+				},
+			},
+			Output: &Common{
+				Type: Object,
+				Children: []*Common{
+					{
+						Name: "foo",
+						Type: Object,
+						Children: []*Common{
+							{
+								Name: "bar",
+								Type: Array,
+								Children: []*Common{
+									{
+										Type: Array,
+										Children: []*Common{
+											{
+												Type: Object,
+												Children: []*Common{
+													{
+														Name: "baz",
+														Type: Array,
+														Children: []*Common{
+															{
+																Type: Int64,
+															},
+														},
+													},
+												},
+											},
+										},
+									},
+								},
+							},
+						},
+					},
+				},
+			},
+		},
+		{
+			Name: "Invalid deeply nested unsupported type",
+			Input: map[string]any{
+				"foo": map[string]any{
+					"bar": []any{
+						[]any{
+							map[string]any{
+								"baz": []any{uint32(10)},
+							},
+						},
+					},
+				},
+			},
+			ErrContains: "unsupported data type",
+		},
+		{
+			Name: "Invalid array mismatched types",
+			Input: []any{
+				"hello world", "this", 10, "is wrong",
+			},
+			ErrContains: "mismatched array types",
+		},
+	} {
+		t.Run(test.Name, func(t *testing.T) {
+			res, err := InferFromAny(test.Input)
+			if test.ErrContains != "" {
+				require.Error(t, err)
+				assert.Contains(t, err.Error(), test.ErrContains)
+			} else {
+				require.NoError(t, err)
+				assert.Equal(t, res, test.Output)
+
+				// Also test serialization and deserialization
+				rtSchema, err := ParseFromAny(res.ToAny())
+				require.NoError(t, err, "Ability to serialize the schema")
+
+				assert.Equal(t, rtSchema, test.Output)
+			}
+		})
+	}
+}

--- a/public/schema/infer_from_any_test.go
+++ b/public/schema/infer_from_any_test.go
@@ -4,6 +4,7 @@ package schema
 
 import (
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -31,6 +32,7 @@ func TestFromAnySchema(t *testing.T) {
 				"baz":   float32(1.1),
 				"buz":   float64(1.2),
 				"moo":   true,
+				"meow":  time.Now().Add(time.Second),
 				"quack": nil,
 			},
 			Output: Common{
@@ -40,6 +42,7 @@ func TestFromAnySchema(t *testing.T) {
 					{Name: "baz", Type: Float32},
 					{Name: "buz", Type: Float64},
 					{Name: "foo", Type: String},
+					{Name: "meow", Type: Timestamp},
 					{Name: "moo", Type: Boolean},
 					{Name: "quack", Type: Null},
 				},

--- a/public/schema/infer_from_any_test.go
+++ b/public/schema/infer_from_any_test.go
@@ -13,13 +13,13 @@ func TestFromAnySchema(t *testing.T) {
 	for _, test := range []struct {
 		Name        string
 		Input       any
-		Output      *Common
+		Output      Common
 		ErrContains string
 	}{
 		{
 			Name:  "Valid scalar schema",
 			Input: 10,
-			Output: &Common{
+			Output: Common{
 				Type: Int64,
 			},
 		},
@@ -33,9 +33,9 @@ func TestFromAnySchema(t *testing.T) {
 				"moo":   true,
 				"quack": nil,
 			},
-			Output: &Common{
+			Output: Common{
 				Type: Object,
-				Children: []*Common{
+				Children: []Common{
 					{Name: "bar", Type: Int32},
 					{Name: "baz", Type: Float32},
 					{Name: "buz", Type: Float64},
@@ -58,27 +58,27 @@ func TestFromAnySchema(t *testing.T) {
 					},
 				},
 			},
-			Output: &Common{
+			Output: Common{
 				Type: Object,
-				Children: []*Common{
+				Children: []Common{
 					{
 						Name: "foo",
 						Type: Object,
-						Children: []*Common{
+						Children: []Common{
 							{
 								Name: "bar",
 								Type: Array,
-								Children: []*Common{
+								Children: []Common{
 									{
 										Type: Array,
-										Children: []*Common{
+										Children: []Common{
 											{
 												Type: Object,
-												Children: []*Common{
+												Children: []Common{
 													{
 														Name: "baz",
 														Type: Array,
-														Children: []*Common{
+														Children: []Common{
 															{
 																Type: Int64,
 															},


### PR DESCRIPTION
The intention of this new package is to be a single place that multiple inputs, processors and outputs can use when sharing schema definitions. It will be possible to create adapters that translate schemas of various types to and from this common format. The goal of this package is to be a common subset of each schemas capabilities rather than a superset in order to maintain as wide a breadth of compatibility as possible.