### PR TITLE
Add exit processor

### DIFF
--- a/internal/impl/pure/processor_exit.go
+++ b/internal/impl/pure/processor_exit.go
@@ -14,7 +14,7 @@ func init() {
 		Categories("Utility").
 		Beta().
 		Summary(`Exit the process with a code.`).
-		Field(service.NewIntField("").Description("The exit code to use.").Default(0))
+		Field(service.NewIntField("").Default(0))
 	service.MustRegisterProcessor(
 		"exit", spec,
 		func(conf *service.ParsedConfig, res *service.Resources) (service.Processor, error) {


### PR DESCRIPTION
Hi,

Added `exit` processor. to stop process with desired status code.
Fix  redpanda-data/connect#3196.

Testing:

```yaml
# test.yaml
input:
  generate:
    count: 1
    mapping: root = 1

pipeline:
  processors:
    - exit: 0

output:
  stdout: {}
```

```sh
$  ./benthos run -s pipeline.processors.0.exit=1 test.yaml 
$ echo $?
# 1
$  ./benthos run -s pipeline.processors.0.exit=0 test.yaml 
$ echo $?
# 0
```

Regards.