### PR TITLE
Add ability to force timely acks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,16 @@ Changelog
 
 All notable changes to this project will be documented in this file.
 
+## 4.55.0 - 2025-08-06
+
+### Added
+
+- Go API: New input wrapping field for forcing timely acknowledgements. (@Jeffail)
+
+### Fixed
+
+- The `/debug/stack` endpoint no longer truncates large traces. (@Jeffail)
+
 ## 4.54.0 - 2025-07-28
 
 ### Added

--- a/internal/api/api.go
+++ b/internal/api/api.go
@@ -99,9 +99,15 @@ func New(
 	}
 
 	handleStackTrace := func(w http.ResponseWriter, r *http.Request) {
-		stackSlice := make([]byte, 1024*100)
-		s := runtime.Stack(stackSlice, true)
-		_, _ = w.Write(stackSlice[:s])
+		buf := make([]byte, 1024)
+		for {
+			n := runtime.Stack(buf, true)
+			if n < len(buf) {
+				_, _ = w.Write(buf[:n])
+				return
+			}
+			buf = make([]byte, 2*len(buf))
+		}
 	}
 
 	handlePrintJSONConfig := func(w http.ResponseWriter, r *http.Request) {

--- a/public/service/config_input.go
+++ b/public/service/config_input.go
@@ -139,3 +139,20 @@ func (p *ParsedConfig) FieldInputMap(path ...string) (map[string]*OwnedInput, er
 
 	return ins, nil
 }
+
+// ForceTimelyNacksFieldName is the configuration field name for enabling a
+// forced timely acknowledgement for messages based on a specified maximum wait
+// period.
+const ForceTimelyNacksFieldName = "timely_nacks_maximum_wait"
+
+// NewForceTimelyNacksField creates a configuration field for enabling a forced
+// maximum period of time whereby messages can be in flight and not
+// acknowledged. If this period is reached before ack or nack then a nack is
+// forced and the message will be rejected or replayed depending on the
+// configuration.
+func NewForceTimelyNacksField() *ConfigField {
+	return NewDurationField(ForceTimelyNacksFieldName).
+		Description("EXPERIMENTAL: Specify a maximum period of time in which each message can be consumed and awaiting either acknowledgement or rejection before rejection is instead forced. This can be useful for avoiding situations where certain downstream components can result in blocked confirmation of delivery that exceeds SLAs.").
+		Advanced().
+		Optional()
+}

--- a/public/service/input_force_timely_nacks.go
+++ b/public/service/input_force_timely_nacks.go
@@ -1,0 +1,81 @@
+// Copyright 2025 Redpanda Data, Inc.
+
+package service
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"time"
+)
+
+// ForceTimelyNacksBatched wraps an input implementation with a timely ack
+// mechanism only if a field defined by NewTimelyNacksField has been specified
+// and is a duration greater than zero.
+func ForceTimelyNacksBatched(c *ParsedConfig, i BatchInput) (BatchInput, error) {
+	if !c.Contains(ForceTimelyNacksFieldName) {
+		return i, nil
+	}
+
+	d, err := c.FieldDuration(ForceTimelyNacksFieldName)
+	if err != nil {
+		return nil, err
+	}
+	if d <= 0 {
+		return i, nil
+	}
+
+	return &forceTimelyNacksInputBatched{
+		logger:          c.Resources().Logger(),
+		maxWaitDuration: d,
+		child:           i,
+	}, nil
+}
+
+var errForceTimelyNacks = errors.New("message acknowledgement exceeded maximum wait and has been rejected")
+
+type forceTimelyNacksInputBatched struct {
+	logger          *Logger
+	maxWaitDuration time.Duration
+	child           BatchInput
+}
+
+func (i *forceTimelyNacksInputBatched) Connect(ctx context.Context) error {
+	return i.child.Connect(ctx)
+}
+
+func (i *forceTimelyNacksInputBatched) ReadBatch(ctx context.Context) (MessageBatch, AckFunc, error) {
+	batch, ackFn, err := i.child.ReadBatch(ctx)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	var ackOnce, closeAckedChanOnce sync.Once
+	ackedChan := make(chan struct{})
+
+	go func() {
+		select {
+		case <-ackedChan:
+			return
+		case <-time.After(i.maxWaitDuration):
+			ackOnce.Do(func() {
+				i.logger.With("duration", i.maxWaitDuration.String()).Warn("Message acknowledgement exceeded our configured maximum wait period and is being rejected as a result")
+				_ = ackFn(context.Background(), errForceTimelyNacks)
+			})
+		}
+	}()
+
+	return batch, func(ctx context.Context, err error) (ackErr error) {
+		closeAckedChanOnce.Do(func() {
+			close(ackedChan)
+		})
+		ackOnce.Do(func() {
+			ackErr = ackFn(ctx, err)
+		})
+		return
+	}, nil
+}
+
+func (i *forceTimelyNacksInputBatched) Close(ctx context.Context) error {
+	return i.child.Close(ctx)
+}

--- a/public/service/input_force_timely_nacks_test.go
+++ b/public/service/input_force_timely_nacks_test.go
@@ -1,0 +1,209 @@
+// Copyright 2025 Redpanda Data, Inc.
+
+package service
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBatchTimelyNacksConfig(t *testing.T) {
+	spec := NewConfigSpec().Field(NewAutoRetryNacksToggleField())
+	for conf, hasMaxWait := range map[string]bool{
+		`{}`:                            false,
+		`timely_nacks_maximum_wait: 0s`: false,
+		`timely_nacks_maximum_wait: 1s`: true,
+	} {
+		inConf, err := spec.ParseYAML(conf, nil)
+		require.NoError(t, err, conf)
+
+		readerImpl := newMockBatchInput()
+		pres, err := ForceTimelyNacksBatched(inConf, readerImpl)
+		require.NoError(t, err, conf)
+
+		_, isWrapped := pres.(*forceTimelyNacksInputBatched)
+		assert.Equal(t, hasMaxWait, isWrapped, conf)
+	}
+}
+
+func TestBatchTimelyNacksClose(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(t.Context(), time.Second*2)
+	defer cancel()
+
+	spec := NewConfigSpec().Field(NewForceTimelyNacksField())
+
+	inConf, err := spec.ParseYAML(`timely_nacks_maximum_wait: 1s`, nil)
+	require.NoError(t, err)
+
+	readerImpl := newMockBatchInput()
+	pres, err := ForceTimelyNacksBatched(inConf, readerImpl)
+	require.NoError(t, err)
+
+	expErr := errors.New("foo error")
+
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+
+	go func() {
+		defer wg.Done()
+
+		err := pres.Connect(ctx)
+		require.NoError(t, err)
+
+		assert.Equal(t, expErr, pres.Close(ctx))
+	}()
+
+	select {
+	case readerImpl.connChan <- nil:
+	case <-time.After(time.Second):
+		t.Error("Timed out")
+	}
+
+	select {
+	case readerImpl.closeChan <- expErr:
+	case <-time.After(time.Second):
+		t.Error("Timed out")
+	}
+
+	wg.Wait()
+}
+
+func TestForceTimelyNacksBatchedHappy(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(t.Context(), time.Second*2)
+	defer cancel()
+
+	readerImpl := newMockBatchInput()
+	readerImpl.msgsToSnd = append(readerImpl.msgsToSnd, MessageBatch{
+		NewMessage([]byte("foo")),
+		NewMessage([]byte("bar")),
+	})
+
+	spec := NewConfigSpec().Field(NewForceTimelyNacksField())
+
+	inConf, err := spec.ParseYAML(`timely_nacks_maximum_wait: 1s`, nil)
+	require.NoError(t, err)
+
+	pres, err := ForceTimelyNacksBatched(inConf, readerImpl)
+	require.NoError(t, err)
+
+	go func() {
+		select {
+		case readerImpl.connChan <- nil:
+		case <-time.After(time.Second):
+			t.Error("Timed out")
+		}
+		select {
+		case readerImpl.readChan <- nil:
+		case <-time.After(time.Second):
+			t.Error("Timed out")
+		}
+		select {
+		case readerImpl.ackChan <- nil:
+		case <-time.After(time.Second):
+			t.Error("Timed out")
+		}
+	}()
+
+	require.NoError(t, pres.Connect(ctx))
+
+	batch, ackFn, err := pres.ReadBatch(ctx)
+	require.NoError(t, err)
+	require.Len(t, batch, 2)
+
+	act, err := batch[0].AsBytes()
+	require.NoError(t, err)
+	assert.Equal(t, "foo", string(act))
+
+	act, err = batch[1].AsBytes()
+	require.NoError(t, err)
+	assert.Equal(t, "bar", string(act))
+
+	require.NoError(t, ackFn(ctx, nil))
+
+	readerImpl.ackRcvdMut.Lock()
+	assert.Len(t, readerImpl.ackRcvd, 1)
+	assert.NoError(t, readerImpl.ackRcvd[0])
+	readerImpl.ackRcvdMut.Unlock()
+}
+
+func TestForceTimelyNacksBatchedNoAck(t *testing.T) {
+	t.Parallel()
+
+	ctx, cancel := context.WithTimeout(t.Context(), time.Second*2)
+	defer cancel()
+
+	readerImpl := newMockBatchInput()
+	readerImpl.msgsToSnd = append(readerImpl.msgsToSnd, MessageBatch{
+		NewMessage([]byte("foo")),
+		NewMessage([]byte("bar")),
+	})
+
+	spec := NewConfigSpec().Field(NewForceTimelyNacksField())
+
+	inConf, err := spec.ParseYAML(`timely_nacks_maximum_wait: 5ms`, nil)
+	require.NoError(t, err)
+
+	pres, err := ForceTimelyNacksBatched(inConf, readerImpl)
+	require.NoError(t, err)
+
+	go func() {
+		select {
+		case readerImpl.connChan <- nil:
+		case <-time.After(time.Second):
+			t.Error("Timed out")
+		}
+		select {
+		case readerImpl.readChan <- nil:
+		case <-time.After(time.Second):
+			t.Error("Timed out")
+		}
+		select {
+		case readerImpl.ackChan <- nil:
+		case <-time.After(time.Second):
+			t.Error("Timed out")
+		}
+	}()
+
+	require.NoError(t, pres.Connect(ctx))
+
+	batch, ackFn, err := pres.ReadBatch(ctx)
+	require.NoError(t, err)
+	require.Len(t, batch, 2)
+
+	act, err := batch[0].AsBytes()
+	require.NoError(t, err)
+	assert.Equal(t, "foo", string(act))
+
+	act, err = batch[1].AsBytes()
+	require.NoError(t, err)
+	assert.Equal(t, "bar", string(act))
+
+	require.Eventually(t, func() bool {
+		readerImpl.ackRcvdMut.Lock()
+		ackLen := len(readerImpl.ackRcvd)
+		readerImpl.ackRcvdMut.Unlock()
+		return ackLen >= 1
+	}, time.Second, time.Millisecond*10)
+
+	readerImpl.ackRcvdMut.Lock()
+	assert.Len(t, readerImpl.ackRcvd, 1)
+	assert.Error(t, readerImpl.ackRcvd[0])
+	readerImpl.ackRcvdMut.Unlock()
+
+	require.NoError(t, ackFn(ctx, nil))
+
+	readerImpl.ackRcvdMut.Lock()
+	assert.Len(t, readerImpl.ackRcvd, 1)
+	assert.Error(t, readerImpl.ackRcvd[0])
+	readerImpl.ackRcvdMut.Unlock()
+}


### PR DESCRIPTION
We're experiencing an issue with some configs containing large and cumbersome networks of outputs that occasionally a message will be blocked for an extended period of time and it is hard to rule these events out, either due to undetected bugs or compounding batch and retry mechanisms.

In order to provide some way of establishing protection against these cases this PR adds a new config field that inputs may opt into, which defines a maximum period of time the system is willing to wait for acknowledgement of an in flight message before the delivery should be undermined with a forced nack.

This is not a system we would want to encourage widely as a short duration here could result in unbounded memory usage. However, as an advanced field it is potentially something we might reach for quite occasionally with "lockstep" inputs such as the suite of kafka inputs.