### PR TITLE
logging: enable timestamp output by default

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ Changelog
 
 All notable changes to this project will be documented in this file.
 
+## TBD
+
+### Changed
+
+- Logging: Enable timestamp output by default (@josephwoodward)
+
 ## 4.55.0 - 2025-08-06
 
 ### Added

--- a/internal/log/docs.go
+++ b/internal/log/docs.go
@@ -13,7 +13,7 @@ func Spec() docs.FieldSpecs {
 			"OFF", "FATAL", "ERROR", "WARN", "INFO", "DEBUG", "TRACE", "ALL", "NONE",
 		).HasDefault("INFO").LinterFunc(nil),
 		docs.FieldString(fieldFormat, "Set the format of emitted logs.").HasOptions("json", "logfmt").HasDefault("logfmt"),
-		docs.FieldBool(fieldAddTimeStamp, "Whether to include timestamps in logs.").HasDefault(false),
+		docs.FieldBool(fieldAddTimeStamp, "Whether to include timestamps in logs.").HasDefault(true),
 		docs.FieldString(fieldLevelName, "The name of the level field added to logs when the `format` is `json`.").HasDefault("level").Advanced(),
 		docs.FieldString(fieldTimestampName, "The name of the timestamp field added to logs when `add_timestamp` is set to `true` and the `format` is `json`.").HasDefault("time").Advanced(),
 		docs.FieldString(fieldMessageName, "The name of the message field added to logs when the `format` is `json`.").HasDefault("msg").Advanced(),


### PR DESCRIPTION
Fixes: https://github.com/redpanda-data/benthos/issues/269

This change enables timestamp output by default, making it easier to diagnose support requests as logs will now include timestamps by default.