### PR TITLE
IDEA: go-json-experiment

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -76,3 +76,5 @@ require (
 go 1.24.1
 
 toolchain go1.24.2
+
+replace encoding/json => github.com/go-json-experiment/json v0.0.0-20250813233538-9b1f9ea2e11b


### PR DESCRIPTION
The encoding/json/v2 package in 1.25 requires export GOEXPERIMENT=jsonv2. This overcomes this complication by replacing json directly with the experimental package LOL.