### PR TITLE
Fix env var loading for test cli command

### DIFF
--- a/internal/cli/test/cli.go
+++ b/internal/cli/test/cli.go
@@ -49,6 +49,10 @@ For more information check out the docs at:
 			return common.PreApplyEnvFilesAndTemplates(c, cliOpts)
 		},
 		Action: func(c *cli.Context) error {
+			if err := cliOpts.CustomRunExtractFn(c); err != nil {
+				return err
+			}
+
 			if len(cliOpts.RootFlags.GetSet(c)) > 0 {
 				return errors.New("cannot override fields with --set (-s) during unit tests")
 			}


### PR DESCRIPTION
The environment variable is not loaded when the test command is run.

This fixes the regression introduced in v4.40.0 (commit https://github.com/redpanda-data/benthos/commit/48e6c4f412737e9b76bd2eab7af8630efb037d3d).

It's the same fix as PR #233
