### PR TITLE
chore: bump Go from 1.25.1 to 1.25.2

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -73,4 +73,4 @@ require (
 	gopkg.in/yaml.v2 v2.4.0 // indirect
 )
 
-go 1.25.1
+go 1.25.2


### PR DESCRIPTION
Bump to Go 1.25.2 to include latest security fixes: https://groups.google.com/g/golang-announce/c/4Emdl2iQ_bI/m/qZN5nc-mBgAJ