### PR TITLE
Use SO_REUSEADDR

### DIFF
--- a/public/utils/netutil/listen.go
+++ b/public/utils/netutil/listen.go
@@ -20,9 +20,9 @@ type ListenerConfig struct {
 	ReusePort bool
 }
 
-// DecorateListenConfig applies ListenerConfig settings to a net.ListenConfig.
+// DecorateListenerConfig applies ListenerConfig settings to a net.ListenConfig.
 // This configures socket options like SO_REUSEADDR and SO_REUSEPORT.
-func DecorateListenConfig(lc *net.ListenConfig, conf ListenerConfig) error {
+func DecorateListenerConfig(lc *net.ListenConfig, conf ListenerConfig) error {
 	// If no options are set, nothing to do
 	if !conf.ReuseAddr && !conf.ReusePort {
 		return nil

--- a/public/utils/netutil/listen_test.go
+++ b/public/utils/netutil/listen_test.go
@@ -21,7 +21,7 @@ func TestDecorateListenConfig(t *testing.T) {
 		ReuseAddr: true,
 	}
 
-	err := DecorateListenConfig(&lc, conf)
+	err := DecorateListenerConfig(&lc, conf)
 	require.NoError(t, err)
 
 	listener1, err := lc.Listen(ctx, "tcp", "127.0.0.1:0")
@@ -52,7 +52,7 @@ func TestListenerConfig_ServerReload(t *testing.T) {
 
 	// Create first server
 	lc1 := net.ListenConfig{}
-	err := DecorateListenConfig(&lc1, conf)
+	err := DecorateListenerConfig(&lc1, conf)
 	require.NoError(t, err)
 
 	listener1, err := lc1.Listen(ctx, "tcp", addr)
@@ -101,7 +101,7 @@ func TestListenerConfig_ServerReload(t *testing.T) {
 
 	// Create second server on same address - should succeed due to SO_REUSEADDR
 	lc2 := net.ListenConfig{}
-	err = DecorateListenConfig(&lc2, conf)
+	err = DecorateListenerConfig(&lc2, conf)
 	require.NoError(t, err)
 
 	listener2, err := lc2.Listen(ctx, "tcp", addr)
@@ -138,7 +138,7 @@ func TestListenerConfig_Empty(t *testing.T) {
 	lc := net.ListenConfig{}
 	conf := ListenerConfig{}
 
-	err := DecorateListenConfig(&lc, conf)
+	err := DecorateListenerConfig(&lc, conf)
 	require.NoError(t, err)
 
 	// Should still be able to listen normally


### PR DESCRIPTION
SO_REUSEADDR allows binding to a port without being blocked by TIME_WAIT sockets (avoiding the "address already in use" error).

I had originally implemented this in https://github.com/redpanda-data/connect/pull/3724, but the excellent comments suggested this be added here instead (so other parts of the code base can make use of it).

This blocks https://github.com/redpanda-data/connect/pull/3724