### PR TITLE
fixed name of keep_alive idle value

### DIFF
--- a/public/utils/netutil/dial.go
+++ b/public/utils/netutil/dial.go
@@ -64,7 +64,7 @@ func DialerConfigFromParsed(pConf *service.ParsedConfig) (DialerConfig, error) {
 	if pConf.Contains("keep_alive") {
 		pc := pConf.Namespace("keep_alive")
 
-		conf.KeepAliveConfig.Idle, err = pc.FieldDuration("keep_alive")
+		conf.KeepAliveConfig.Idle, err = pc.FieldDuration("idle")
 		if err != nil {
 			return conf, err
 		}


### PR DESCRIPTION
The value name should be "idle". Without this change, it will fail the lint checks and won't work. 