### PR TITLE
adding new listener opts to input socket_server

### DIFF
--- a/public/utils/netutil/listen.go
+++ b/public/utils/netutil/listen.go
@@ -1,5 +1,6 @@
-// Copyright 2025 Redpanda Data, Inc.
+//go:build !wasm
 
+// Copyright 2025 Redpanda Data, Inc.
 package netutil
 
 import (


### PR DESCRIPTION
In certain cases, customers using the `socket_server` input component may want to have the ability to reuse the same port when running multiple connect processes. This allows multiple processes (e.g., multiple Redpanda Connect instances) to bind to the same address and port, enabling kernel-level load balancing of incoming connections.