### PR TITLE
netutil: add support for Windows

### DIFF
--- a/public/utils/netutil/dial.go
+++ b/public/utils/netutil/dial.go
@@ -159,7 +159,7 @@ func wrapControlContext(inner controlContextFunc, conf DialerConfig) controlCont
 
 		var syscallErr error
 		if err := conn.Control(func(fd uintptr) {
-			syscallErr = syscall.SetsockoptInt(int(fd), syscall.IPPROTO_TCP,
+			syscallErr = setsockoptInt(fd, syscall.IPPROTO_TCP,
 				tcpUserTimeout, int(conf.TCPUserTimeout.Milliseconds()))
 		}); err != nil {
 			return fmt.Errorf("failed to set tcp_user_timeout: %w", err)

--- a/public/utils/netutil/listen.go
+++ b/public/utils/netutil/listen.go
@@ -82,7 +82,7 @@ func DecorateListenerConfig(lc *net.ListenConfig, conf ListenerConfig) error {
 		var sockOptErr error
 		if err := c.Control(func(fd uintptr) {
 			if conf.ReuseAddr {
-				sockOptErr = syscall.SetsockoptInt(int(fd), syscall.SOL_SOCKET, syscall.SO_REUSEADDR, 1)
+				sockOptErr = setsockoptInt(fd, syscall.SOL_SOCKET, syscall.SO_REUSEADDR, 1)
 				if sockOptErr != nil {
 					return
 				}
@@ -91,7 +91,7 @@ func DecorateListenerConfig(lc *net.ListenConfig, conf ListenerConfig) error {
 			if conf.ReusePort {
 				// SO_REUSEPORT = 15 on Linux, not available on all platforms
 				const SO_REUSEPORT = 0x0F
-				sockOptErr = syscall.SetsockoptInt(int(fd), syscall.SOL_SOCKET, SO_REUSEPORT, 1)
+				sockOptErr = setsockoptInt(fd, syscall.SOL_SOCKET, SO_REUSEPORT, 1)
 				if sockOptErr != nil {
 					// Ignore error if SO_REUSEPORT is not supported on this platform
 					// This allows the code to work across different OSes

--- a/public/utils/netutil/syscall_others.go
+++ b/public/utils/netutil/syscall_others.go
@@ -1,0 +1,12 @@
+//go:build !windows
+
+// Copyright 2025 Redpanda Data, Inc.
+
+package netutil
+
+import "syscall"
+
+// setsockoptInt wraps syscall.SetsockoptInt for Unix-like systems.
+func setsockoptInt(fd uintptr, level, opt, value int) error {
+	return syscall.SetsockoptInt(int(fd), level, opt, value)
+}

--- a/public/utils/netutil/syscall_windows.go
+++ b/public/utils/netutil/syscall_windows.go
@@ -1,0 +1,12 @@
+//go:build windows
+
+// Copyright 2025 Redpanda Data, Inc.
+
+package netutil
+
+import "syscall"
+
+// setsockoptInt wraps syscall.SetsockoptInt for Windows.
+func setsockoptInt(fd uintptr, level, opt, value int) error {
+	return syscall.SetsockoptInt(syscall.Handle(fd), level, opt, value)
+}


### PR DESCRIPTION
Without this patch Windows build fail with

```
    error=
    │ build failed: exit status 1: # github.com/redpanda-data/benthos/v4/public/utils/netutil
    │ ../../../Go/pkg/mod/github.com/redpanda-data/benthos/v4@v4.59.0/public/utils/netutil/dial.go:146:39: cannot use int(fd) (value of type int) as syscall.Handle value in argument to syscall.SetsockoptInt
    │ ../../../Go/pkg/mod/github.com/redpanda-data/benthos/v4@v4.59.0/public/utils/netutil/listen.go:45:40: cannot use int(fd) (value of type int) as syscall.Handle value in argument to syscall.SetsockoptInt
    │ ../../../Go/pkg/mod/github.com/redpanda-data/benthos/v4@v4.59.0/public/utils/netutil/listen.go:54:40: cannot use int(fd) (value of type int) as syscall.Handle value in argument to syscall.SetsockoptInt
    target=windows_amd64_v1
```