### PR TITLE
adding unixgram option to input socket server

### DIFF
--- a/internal/impl/io/input_socket_server.go
+++ b/internal/impl/io/input_socket_server.go
@@ -48,7 +48,7 @@ func socketServerInputSpec() *service.ConfigSpec {
 		Summary(`Creates a server that receives a stream of messages over a TCP, UDP or Unix socket.`).
 		Categories("Network").
 		Fields(
-			service.NewStringEnumField(issFieldNetwork, "unix", "tcp", "udp", "tls").
+			service.NewStringEnumField(issFieldNetwork, "unix", "tcp", "udp", "tls", "unixgram").
 				Description("A network type to accept."),
 			service.NewStringField(isFieldAddress).
 				Description("The address to listen from.").
@@ -182,7 +182,7 @@ func (t *socketServerInput) Connect(ctx context.Context) error {
 			ClientAuth:   t.tlsClientAuth,
 		}
 		ln, err = tls.Listen("tcp", t.address, config)
-	case "udp":
+	case "udp", "unixgram":
 		cn, err = net.ListenPacket(t.network, t.address)
 	default:
 		return fmt.Errorf("socket network '%v' is not supported by this input", t.network)
@@ -203,7 +203,7 @@ func (t *socketServerInput) Connect(ctx context.Context) error {
 		t.log.Infof("Receiving %v socket messages from address: %v", t.network, addr.String())
 	} else {
 		addr = cn.LocalAddr()
-		t.log.Infof("Receiving udp socket messages from address: %v", addr.String())
+		t.log.Infof("Receiving %v socket messages from address: %v", t.network, addr.String())
 	}
 	if t.addressCache != "" {
 		key := "socket_server_address"

--- a/internal/stream/type.go
+++ b/internal/stream/type.go
@@ -182,13 +182,13 @@ func (t *Type) start() (err error) {
 	}
 
 	go func(out output.Streamed) {
-		for {
-			if err := out.WaitForClose(context.Background()); err == nil {
-				t.onClose()
-				atomic.StoreUint32(&t.closed, 1)
-				return
-			}
+		// WaitForClose blocks until output is fully closed.
+		// Errors indicate close completed with issues, but output is still closed.
+		if err := out.WaitForClose(context.Background()); err != nil {
+			t.manager.Logger().Debug("Output close completed with error: %v", err)
 		}
+		t.onClose()
+		atomic.StoreUint32(&t.closed, 1)
 	}(t.outputLayer)
 
 	return nil


### PR DESCRIPTION
When using the UNIX socket option, the connection is configured for "streams". However, there might be use cases where one would need "Datagram" instead. For example nginx outputs datagrams on the unix socket.

ListenPacket already has the ability for us to pass "unixgram"  as the network type, which will create the datagram connection, so we just need to add the option as one of the network choices.
