### PR TITLE
Bump Go toolchain to 1.26.3 to address Snyk findings

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/redpanda-data/benthos/v4
 
-go 1.26.1
+go 1.26.3
 
 require (
 	cuelang.org/go v0.16.1


### PR DESCRIPTION
## Summary

Bumps the Go directive in `go.mod` from 1.26.1 to 1.26.3 to resolve three HIGH severity stdlib findings reported by Snyk against `benthos:go.mod`:

- **CVE-2026-33811** — Double Free in `std/net` (Snyk: SNYK-GOLANG-STDNET-16535159, Go vuln: GO-2026-4981)
- **CVE-2026-39836** — Uncaught Exception in `std/net` (Snyk: SNYK-GOLANG-STDNET-16535161, Go vuln: GO-2026-4971)
- **CVE-2026-33814** — Infinite loop in `std/net/http` (Snyk: SNYK-GOLANG-STDNETHTTP-16535158, Go vuln: GO-2026-4918)

## Note on Snyk "no fix" reporting

Snyk's database currently reports these as having no fix available — that's DB lag. The OSV database and the upstream Go vulnerability database both confirm Go 1.26.3 is the fix release for all three:

- https://pkg.go.dev/vuln/GO-2026-4981
- https://pkg.go.dev/vuln/GO-2026-4971
- https://pkg.go.dev/vuln/GO-2026-4918

Once Snyk's DB catches up, these findings will close out automatically against this version.

## Test plan

- [ ] CI green