### PR TITLE
Build skipList before exclude enrichment in apply section

### DIFF
--- a/internal/impl/pure/processor_workflow.go
+++ b/internal/impl/pure/processor_workflow.go
@@ -398,6 +398,17 @@ func (w *Workflow) skipFromMeta(root any) map[string]struct{} {
 
 	gObj := gabs.Wrap(root)
 
+	// Skip stages that were already skipped in a previous run of this workflow.
+	if skipped, ok := gObj.S(append(w.metaPath, "skipped")...).Data().([]any); ok {
+		for _, id := range skipped {
+			if idStr, isString := id.(string); isString {
+				if _, exists := w.allStages[idStr]; exists {
+					skipList[idStr] = struct{}{}
+				}
+			}
+		}
+	}
+
 	// If a whitelist is provided for this flow then skip stages that aren't
 	// within it.
 	if apply, ok := gObj.S(append(w.metaPath, "apply")...).Data().([]any); ok {
@@ -416,17 +427,6 @@ func (w *Workflow) skipFromMeta(root any) map[string]struct{} {
 	// Skip stages that already succeeded in a previous run of this workflow.
 	if succeeded, ok := gObj.S(append(w.metaPath, "succeeded")...).Data().([]any); ok {
 		for _, id := range succeeded {
-			if idStr, isString := id.(string); isString {
-				if _, exists := w.allStages[idStr]; exists {
-					skipList[idStr] = struct{}{}
-				}
-			}
-		}
-	}
-
-	// Skip stages that were already skipped in a previous run of this workflow.
-	if skipped, ok := gObj.S(append(w.metaPath, "skipped")...).Data().([]any); ok {
-		for _, id := range skipped {
 			if idStr, isString := id.(string); isString {
 				if _, exists := w.allStages[idStr]; exists {
 					skipList[idStr] = struct{}{}

--- a/internal/impl/pure/processor_workflow_test.go
+++ b/internal/impl/pure/processor_workflow_test.go
@@ -396,11 +396,13 @@ func TestWorkflows(t *testing.T) {
 				msg(`{"meta":{"workflow":{"apply":["2"]}},"baz":2}`),
 				msg(`{"meta":{"workflow":{"skipped":["0"]}},"bar":3}`),
 				msg(`{"meta":{"workflow":{"succeeded":["1"]}},"baz":9}`),
+				msg(`{"bar":3,"baz":2,"meta":{"workflow":{"apply":["1","2"],"failed":{"0":"request mapping failed: failed assignment (line 1): field ` + "`this.foo`" + `: value is null"},"skipped":["1","2"]}}}`),
 			},
 			output: []mockMsg{
 				msg(`{"baz":2,"buz":4,"meta":{"workflow":{"previous":{"apply":["2"]},"skipped":["0","1"],"succeeded":["2"]}}}`),
 				msg(`{"bar":3,"baz":8,"buz":10,"meta":{"workflow":{"previous":{"skipped":["0"]},"skipped":["0"],"succeeded":["1","2"]}}}`),
 				msg(`{"baz":9,"buz":11,"meta":{"workflow":{"failed":{"0":"request mapping failed: failed assignment (line 1): field ` + "`this.foo`" + `: value is null"},"previous":{"succeeded":["1"]},"skipped":["1"],"succeeded":["2"]}}}`),
+				msg(`{"bar":3,"baz":8,"buz":10,"meta":{"workflow":{"previous":{"apply":["1","2"],"failed":{"0":"request mapping failed: failed assignment (line 1): field ` + "`this.foo`" + `: value is null"},"skipped":["1","2"]},"skipped":["0"],"succeeded":["1","2"]}}}`),
 			},
 		},
 		{


### PR DESCRIPTION
(This PR is related [with this issue](https://github.com/redpanda-data/benthos/issues/438))

Currently have an issue, all enrichments listed in `apply` meta are not replayed. We added this processor to replay all enrichment, even skipped ones because, some of them can be skipped because of a dependencies issue with the failed one. We added this processor before the workflow:

```
- label: replay_skipped
  switch:
    - check: this.meta.enrichments.exists("skipped") && this.meta.enrichments.skipped.length() > 0
      processors:
        - label: replay_skipped_enrichments
          bloblang: |-
            root = this
            root.meta.enrichments.apply = this.meta.enrichments.failed.keys().merge(this.meta.enrichments.skipped)
```

Our workflow looks like that
```
---
processor_resources:
  - label: enrichments
    workflow:
      meta_path: meta.enrichments
      order:
...
```

But, in the document resulted, the enrichments listed in `apply` are not replayed, only the one previously in `failed` is replayed. They are not listed in `succeeded`, they are in `skipped` and the field added by enrichment are not present.

I'm not expert in Go but in my PR, if I well understand, in function skipFromMeta, the `if skipped` section should be before the `if apply` one because the `if apply` will remove the enrichment from the list `skipList` filled by the `if skipped` section.

I wrote test to validate if we have the expected result and it's works 🍾 

I run tests for others functions `TestWorkflows`, `TestWorkflowsDeps`, `TestWorkflowsParallel` and `TestWorkflowsWithOrderResources`

I run workflow tests `TestWorkflows`, `TestWorkflowsDeps`, `TestWorkflowsParallel` and `TestWorkflowsWithOrderResources`

```
⋊> ~/D/benthos on workflow_switch_apply_retry  go test -v ./internal/impl/pure/ -run TestWorkflows                                               
=== RUN   TestWorkflows
=== RUN   TestWorkflows/0
=== RUN   TestWorkflows/1
=== RUN   TestWorkflows/2
=== RUN   TestWorkflows/3
=== RUN   TestWorkflows/4
--- PASS: TestWorkflows (0.01s)
    --- PASS: TestWorkflows/0 (0.00s)
    --- PASS: TestWorkflows/1 (0.00s)
    --- PASS: TestWorkflows/2 (0.00s)
    --- PASS: TestWorkflows/3 (0.00s)
    --- PASS: TestWorkflows/4 (0.00s)
=== RUN   TestWorkflowsWithResources
=== RUN   TestWorkflowsWithResources/0
=== RUN   TestWorkflowsWithResources/1
=== RUN   TestWorkflowsWithResources/2
=== RUN   TestWorkflowsWithResources/3
--- PASS: TestWorkflowsWithResources (0.00s)
    --- PASS: TestWorkflowsWithResources/0 (0.00s)
    --- PASS: TestWorkflowsWithResources/1 (0.00s)
    --- PASS: TestWorkflowsWithResources/2 (0.00s)
    --- PASS: TestWorkflowsWithResources/3 (0.00s)
=== RUN   TestWorkflowsParallel
--- PASS: TestWorkflowsParallel (0.46s)
=== RUN   TestWorkflowsWithOrderResources
=== RUN   TestWorkflowsWithOrderResources/0
=== RUN   TestWorkflowsWithOrderResources/1
=== RUN   TestWorkflowsWithOrderResources/2
=== RUN   TestWorkflowsWithOrderResources/3
--- PASS: TestWorkflowsWithOrderResources (0.01s)
    --- PASS: TestWorkflowsWithOrderResources/0 (0.00s)
    --- PASS: TestWorkflowsWithOrderResources/1 (0.00s)
    --- PASS: TestWorkflowsWithOrderResources/2 (0.00s)
    --- PASS: TestWorkflowsWithOrderResources/3 (0.00s)
PASS
ok      github.com/redpanda-data/benthos/v4/internal/impl/pure  0.997s
```