### PR TITLE
Add opt-in strict error handling and a try_catch processor

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ All notable changes to this project will be documented in this file.
 
 - Processor: Added a `try_catch` processor that executes a list of `processors` with "try" semantics and routes any failed message to a separate list of `catch` processors for recovery. Before the `catch` processors run, the failure is moved into a metadata object (`error` by default, configurable via `error_metadata`) with `what`/`name`/`label`/`path` fields, and the message's failure flag is cleared, so the recovery runs under the normal error semantics and the original error is available as a variable (e.g. `@error.what`). (@Jeffail)
 - Config: Added an `error_handling.strict` field (default `false`). When enabled, a processing error is terminal for the affected message: it skips the remaining processors in its pipeline and is rejected (nacked) at the output rather than written. Expected errors are recovered by wrapping the fallible step within a `try_catch` (or `retry`) processor. This behaviour is expected to become the default in the next major version. (@Jeffail)
+- Linting: With `error_handling.strict` enabled, a lint warning is now raised for any `catch` processor (at any nesting depth), since under strict error handling a failed message short-circuits past it and it will never recover anything; recovery should use `try_catch` instead. (@Jeffail)
 
 ## 4.75.0 - 2026-06-18
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ Changelog
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+### Added
+
+- Processor: Added a `try_catch` processor that executes a list of `processors` with "try" semantics and routes any failed message to a separate list of `catch` processors for recovery. Before the `catch` processors run, the failure is moved into a metadata object (`error` by default, configurable via `error_metadata`) with `what`/`name`/`label`/`path` fields, and the message's failure flag is cleared, so the recovery runs under the normal error semantics and the original error is available as a variable (e.g. `@error.what`). (@Jeffail)
+
 ## 4.75.0 - 2026-06-18
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ All notable changes to this project will be documented in this file.
 ### Added
 
 - Processor: Added a `try_catch` processor that executes a list of `processors` with "try" semantics and routes any failed message to a separate list of `catch` processors for recovery. Before the `catch` processors run, the failure is moved into a metadata object (`error` by default, configurable via `error_metadata`) with `what`/`name`/`label`/`path` fields, and the message's failure flag is cleared, so the recovery runs under the normal error semantics and the original error is available as a variable (e.g. `@error.what`). (@Jeffail)
+- Config: Added an `error_handling.strict` field (default `false`). When enabled, a processing error is terminal for the affected message: it skips the remaining processors in its pipeline and is rejected (nacked) at the output rather than written. Expected errors are recovered by wrapping the fallible step within a `try_catch` (or `retry`) processor. This behaviour is expected to become the default in the next major version. (@Jeffail)
 
 ## 4.75.0 - 2026-06-18
 

--- a/internal/bundle/package.go
+++ b/internal/bundle/package.go
@@ -48,6 +48,12 @@ type NewManagement interface {
 
 	EngineVersion() string
 
+	// Strict reports whether the engine is configured for strict error handling,
+	// where a processing error is terminal for the affected message unless
+	// recovered by wrapping the fallible step within a try_catch or retry
+	// processor.
+	Strict() bool
+
 	Path() []string
 	Label() string
 	StreamID() string

--- a/internal/cli/common/manager.go
+++ b/internal/cli/common/manager.go
@@ -98,6 +98,7 @@ func CreateManager(
 	mgrOpts = append([]manager.OptFunc{
 		manager.OptSetAPIReg(httpServer),
 		manager.OptSetEngineVersion(cliOpts.Version),
+		manager.OptSetStrict(conf.ErrorHandling.Strict),
 		manager.OptSetStreamHTTPNamespacing(c.Bool("prefix-stream-endpoints")),
 		manager.OptSetLogger(logger),
 		manager.OptSetMetrics(stats),

--- a/internal/component/input/processors/append.go
+++ b/internal/component/input/processors/append.go
@@ -27,7 +27,7 @@ func AppendFromConfig(conf input.Config, mgr bundle.NewManagement, pipelines ...
 					return nil, fmt.Errorf("failed to create processor '%v': %v", procConf.Type, err)
 				}
 			}
-			return pipeline.NewProcessor(processors...), nil
+			return pipeline.NewProcessor(mgr.Strict(), processors...), nil
 		}}, pipelines...)
 	}
 	return pipelines

--- a/internal/component/input/wrap_with_pipeline_test.go
+++ b/internal/component/input/wrap_with_pipeline_test.go
@@ -232,8 +232,8 @@ func TestBasicWrapProcessors(t *testing.T) {
 
 	mockIn := &mockInput{ts: make(chan message.Transaction)}
 
-	pipe1 := pipeline.NewProcessor(mockProc{})
-	pipe2 := pipeline.NewProcessor(mockProc{})
+	pipe1 := pipeline.NewProcessor(false, mockProc{})
+	pipe2 := pipeline.NewProcessor(false, mockProc{})
 
 	newInput, err := input.WrapWithPipelines(mockIn, func() (iprocessor.Pipeline, error) {
 		return pipe1, nil
@@ -303,7 +303,7 @@ func TestBasicWrapDoubleProcessors(t *testing.T) {
 
 	mockIn := &mockInput{ts: make(chan message.Transaction)}
 
-	pipe1 := pipeline.NewProcessor(mockProc{}, mockProc{})
+	pipe1 := pipeline.NewProcessor(false, mockProc{}, mockProc{})
 
 	newInput, err := input.WrapWithPipelines(mockIn, func() (iprocessor.Pipeline, error) {
 		return pipe1, nil

--- a/internal/component/output/async_writer.go
+++ b/internal/component/output/async_writer.go
@@ -5,6 +5,7 @@ package output
 import (
 	"context"
 	"errors"
+	"fmt"
 	"sync"
 	"sync/atomic"
 	"time"
@@ -52,6 +53,7 @@ type AsyncWriter struct {
 
 	typeStr     string
 	maxInflight int
+	strict      bool
 	writer      AsyncSink
 
 	mgr    component.Observability
@@ -65,11 +67,14 @@ type AsyncWriter struct {
 	shutSig   *shutdown.Signaller
 }
 
-// NewAsyncWriter creates a Streamed implementation around an AsyncSink.
-func NewAsyncWriter(typeStr string, maxInflight int, w AsyncSink, mgr component.Observability) (Streamed, error) {
+// NewAsyncWriter creates a Streamed implementation around an AsyncSink. When
+// strict is true, messages that arrive already flagged as failed are rejected
+// (nacked) rather than written, on a per-message basis.
+func NewAsyncWriter(typeStr string, maxInflight int, strict bool, w AsyncSink, mgr component.Observability) (Streamed, error) {
 	aWriter := &AsyncWriter{
 		typeStr:      typeStr,
 		maxInflight:  maxInflight,
+		strict:       strict,
 		writer:       w,
 		mgr:          mgr,
 		log:          mgr.Logger(),
@@ -100,6 +105,7 @@ func (w *AsyncWriter) loop() {
 		mSent       = w.stats.GetCounter("output_sent")
 		mBatchSent  = w.stats.GetCounter("output_batch_sent")
 		mError      = w.stats.GetCounter("output_error")
+		mRejected   = w.stats.GetCounter("output_rejected")
 		mLatency    = w.stats.GetTimer("output_latency_ns")
 		mConn       = w.stats.GetCounter("output_connection_up")
 		mFailedConn = w.stats.GetCounter("output_connection_failed")
@@ -211,14 +217,82 @@ func (w *AsyncWriter) loop() {
 				return
 			}
 
-			w.log.Trace("Attempting to write %v messages to '%v'.\n", ts.Payload.Len(), w.typeStr)
-			_, spans := tracing.WithChildSpans(w.tracer, traceName, ts.Payload)
+			payload := ts.Payload
+			ackFn := ts.Ack
 
-			latency, err := w.latencyMeasuringWrite(closeLeisureCtx, ts.Payload)
+			// In strict mode, messages that have already failed a processing step
+			// are rejected (nacked) rather than written, on a per-message basis.
+			if w.strict {
+				var rejectErr *batch.Error
+				var sampleErr error
+				for i, m := range payload {
+					mErr := m.ErrorGet()
+					if mErr == nil {
+						continue
+					}
+					if sampleErr == nil {
+						sampleErr = mErr
+					}
+					mErr = fmt.Errorf("rejected due to failed processing: %w", mErr)
+					if rejectErr == nil {
+						rejectErr = batch.NewError(payload, mErr)
+					}
+					rejectErr.Failed(i, mErr)
+				}
+
+				if rejectErr != nil {
+					mRejected.Incr(int64(rejectErr.IndexedErrors()))
+					w.log.Warn("Rejecting %v of %v message(s) for output '%v' because they failed a processing step and strict error handling is enabled (example error: %v). To recover from expected errors and allow these messages through, wrap the failing step within a try_catch (or retry) processor; otherwise they will be nacked and retried by the input.\n", rejectErr.IndexedErrors(), len(payload), w.typeStr, sampleErr)
+
+					if rejectErr.IndexedErrors() == len(payload) {
+						// Every message failed: nack the whole batch without writing.
+						_ = ts.Ack(closeLeisureCtx, rejectErr)
+						continue
+					}
+
+					// Mixed batch: write only the messages that did not fail, and
+					// merge any write failure back into the rejection error.
+					sortGroup, sortedBatch := message.NewSortGroup(payload)
+					forwardBatch := make(message.Batch, 0, len(payload)-rejectErr.IndexedErrors())
+					rejectErr.WalkPartsNaively(func(i int, _ *message.Part, err error) bool {
+						if err == nil {
+							forwardBatch = append(forwardBatch, sortedBatch[i])
+						}
+						return true
+					})
+					payload = forwardBatch
+					ackFn = func(ctx context.Context, werr error) error {
+						if werr == nil {
+							return ts.Ack(ctx, rejectErr)
+						}
+						var tmpBatchErr *batch.Error
+						if errors.As(werr, &tmpBatchErr) {
+							tmpBatchErr.WalkPartsBySource(sortGroup, sortedBatch, func(i int, _ *message.Part, err error) bool {
+								if err != nil {
+									rejectErr.Failed(i, err)
+								}
+								return true
+							})
+							return ts.Ack(ctx, rejectErr)
+						}
+						for _, p := range forwardBatch {
+							if i := sortGroup.GetIndex(p); i >= 0 {
+								rejectErr.Failed(i, werr)
+							}
+						}
+						return ts.Ack(ctx, rejectErr)
+					}
+				}
+			}
+
+			w.log.Trace("Attempting to write %v messages to '%v'.\n", payload.Len(), w.typeStr)
+			_, spans := tracing.WithChildSpans(w.tracer, traceName, payload)
+
+			latency, err := w.latencyMeasuringWrite(closeLeisureCtx, payload)
 
 			// If our writer says it is not connected.
 			if errors.Is(err, component.ErrNotConnected) {
-				latency, err = connectLoop(ts.Payload)
+				latency, err = connectLoop(payload)
 			} else if err != nil {
 				mError.Incr(1)
 			}
@@ -238,16 +312,16 @@ func (w *AsyncWriter) loop() {
 				}
 			} else {
 				mBatchSent.Incr(1)
-				mSent.Incr(int64(batch.MessageCollapsedCount(ts.Payload)))
+				mSent.Incr(int64(batch.MessageCollapsedCount(payload)))
 				mLatency.Timing(latency)
-				w.log.Trace("Successfully wrote %v messages to '%v'.\n", ts.Payload.Len(), w.typeStr)
+				w.log.Trace("Successfully wrote %v messages to '%v'.\n", payload.Len(), w.typeStr)
 			}
 
 			for _, s := range spans {
 				s.Finish()
 			}
 
-			_ = ts.Ack(closeLeisureCtx, err)
+			_ = ackFn(closeLeisureCtx, err)
 		}
 	}
 

--- a/internal/component/output/async_writer_strict_test.go
+++ b/internal/component/output/async_writer_strict_test.go
@@ -1,0 +1,156 @@
+// Copyright 2026 Redpanda Data, Inc.
+
+package output
+
+import (
+	"context"
+	"errors"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/redpanda-data/benthos/v4/internal/batch"
+	"github.com/redpanda-data/benthos/v4/internal/component"
+	"github.com/redpanda-data/benthos/v4/internal/message"
+)
+
+// recordingWriter is an always-connected AsyncSink that records the content of
+// every batch it is asked to write.
+type recordingWriter struct {
+	mu       sync.Mutex
+	written  [][]string
+	writeErr error
+}
+
+func (w *recordingWriter) ConnectionTest(context.Context) component.ConnectionTestResults {
+	return nil
+}
+func (w *recordingWriter) Connect(context.Context) error { return nil }
+
+func (w *recordingWriter) WriteBatch(_ context.Context, msg message.Batch) error {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	var got []string
+	_ = msg.Iter(func(_ int, p *message.Part) error {
+		got = append(got, string(p.AsBytes()))
+		return nil
+	})
+	w.written = append(w.written, got)
+	return w.writeErr
+}
+func (w *recordingWriter) Close(context.Context) error { return nil }
+
+func (w *recordingWriter) writes() [][]string {
+	w.mu.Lock()
+	defer w.mu.Unlock()
+	out := make([][]string, len(w.written))
+	copy(out, w.written)
+	return out
+}
+
+func sendForAck(t *testing.T, tChan chan message.Transaction, b message.Batch) error {
+	t.Helper()
+	resChan := make(chan error)
+	select {
+	case tChan <- message.NewTransaction(b, resChan):
+	case <-time.After(time.Second):
+		t.Fatal("timed out sending transaction")
+	}
+	select {
+	case err := <-resChan:
+		return err
+	case <-time.After(time.Second):
+		t.Fatal("timed out waiting for ack")
+	}
+	return nil
+}
+
+func startWriter(t *testing.T, strict bool, w AsyncSink) (Streamed, chan message.Transaction) {
+	t.Helper()
+	aw, err := NewAsyncWriter("foo", 1, strict, w, component.NoopObservability())
+	require.NoError(t, err)
+	tChan := make(chan message.Transaction)
+	require.NoError(t, aw.Consume(tChan))
+	aw.TriggerStartConsuming()
+	t.Cleanup(func() {
+		aw.TriggerCloseNow()
+		ctx, done := context.WithTimeout(context.Background(), time.Second*5)
+		defer done()
+		_ = aw.WaitForClose(ctx)
+	})
+	return aw, tChan
+}
+
+// In strict mode a mixed batch writes only the messages that did not fail, and
+// the failed message is nacked via a batch error.
+func TestAsyncWriterStrictRejectsMixedBatch(t *testing.T) {
+	w := &recordingWriter{}
+	_, tChan := startWriter(t, true, w)
+
+	b := message.QuickBatch([][]byte{[]byte("a"), []byte("b"), []byte("c")})
+	b.Get(1).ErrorSet(errors.New("boom"))
+
+	ackErr := sendForAck(t, tChan, b)
+
+	require.Error(t, ackErr, "the failed message must be nacked")
+	var bErr *batch.Error
+	require.ErrorAs(t, ackErr, &bErr)
+	assert.Equal(t, 1, bErr.IndexedErrors(), "exactly one message rejected")
+
+	assert.Equal(t, [][]string{{"a", "c"}}, w.writes(), "only the non-failed messages are written")
+}
+
+// In strict mode, when the write of the surviving (non-failed) messages itself
+// fails, that failure is merged with the rejections so the whole batch is
+// nacked.
+func TestAsyncWriterStrictMixedBatchWriteFails(t *testing.T) {
+	w := &recordingWriter{writeErr: errors.New("sink unavailable")}
+	_, tChan := startWriter(t, true, w)
+
+	b := message.QuickBatch([][]byte{[]byte("a"), []byte("b"), []byte("c")})
+	b.Get(1).ErrorSet(errors.New("boom")) // rejected by processing
+
+	ackErr := sendForAck(t, tChan, b)
+
+	require.Error(t, ackErr)
+	var bErr *batch.Error
+	require.ErrorAs(t, ackErr, &bErr)
+	assert.Equal(t, 3, bErr.IndexedErrors(), "all three messages nacked: one rejected, two failed to write")
+	assert.Equal(t, [][]string{{"a", "c"}}, w.writes(), "only the non-rejected messages were attempted")
+}
+
+// In strict mode a batch in which every message has failed is nacked without
+// any write taking place.
+func TestAsyncWriterStrictRejectsWholeBatch(t *testing.T) {
+	w := &recordingWriter{}
+	_, tChan := startWriter(t, true, w)
+
+	b := message.QuickBatch([][]byte{[]byte("a"), []byte("b")})
+	_ = b.Iter(func(_ int, p *message.Part) error {
+		p.ErrorSet(errors.New("boom"))
+		return nil
+	})
+
+	ackErr := sendForAck(t, tChan, b)
+
+	require.Error(t, ackErr)
+	assert.Empty(t, w.writes(), "no write should occur when every message failed")
+}
+
+// Without strict mode, a message that arrives flagged as failed is still written
+// (the historical behaviour) and the batch is acked.
+func TestAsyncWriterNonStrictWritesErrored(t *testing.T) {
+	w := &recordingWriter{}
+	_, tChan := startWriter(t, false, w)
+
+	b := message.QuickBatch([][]byte{[]byte("a"), []byte("b")})
+	b.Get(0).ErrorSet(errors.New("boom"))
+
+	ackErr := sendForAck(t, tChan, b)
+
+	require.NoError(t, ackErr)
+	assert.Equal(t, [][]string{{"a", "b"}}, w.writes(), "without strict the errored message is still written")
+}

--- a/internal/component/output/async_writer_test.go
+++ b/internal/component/output/async_writer_test.go
@@ -83,7 +83,7 @@ func (w *writerCantSend) Close(context.Context) error { return nil }
 func TestAsyncWriterCantConnect(t *testing.T) {
 	t.Parallel()
 
-	w, err := NewAsyncWriter("foo", 1, writerCantConnect{}, component.NoopObservability())
+	w, err := NewAsyncWriter("foo", 1, false, writerCantConnect{}, component.NoopObservability())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -112,7 +112,7 @@ func TestAsyncWriterCantSendClosed(t *testing.T) {
 
 	writerImpl := &writerCantSend{}
 
-	w, err := NewAsyncWriter("foo", 1, writerImpl, component.NoopObservability())
+	w, err := NewAsyncWriter("foo", 1, false, writerImpl, component.NoopObservability())
 	if err != nil {
 		t.Error(err)
 		return
@@ -138,7 +138,7 @@ func TestAsyncWriterCantSendClosedChan(t *testing.T) {
 
 	writerImpl := &writerCantSend{}
 
-	w, err := NewAsyncWriter("foo", 1, writerImpl, component.NoopObservability())
+	w, err := NewAsyncWriter("foo", 1, false, writerImpl, component.NoopObservability())
 	if err != nil {
 		t.Error(err)
 		return
@@ -167,7 +167,7 @@ func TestAsyncWriterStartClosed(t *testing.T) {
 
 	writerImpl := newAsyncMockWriter()
 
-	w, err := NewAsyncWriter("foo", 1, writerImpl, component.NoopObservability())
+	w, err := NewAsyncWriter("foo", 1, false, writerImpl, component.NoopObservability())
 	if err != nil {
 		t.Error(err)
 		return
@@ -198,7 +198,7 @@ func TestAsyncWriterClosesOnReconn(t *testing.T) {
 
 	writerImpl := newAsyncMockWriter()
 
-	w, err := NewAsyncWriter("foo", 1, writerImpl, component.NoopObservability())
+	w, err := NewAsyncWriter("foo", 1, false, writerImpl, component.NoopObservability())
 	if err != nil {
 		t.Error(err)
 		return
@@ -249,7 +249,7 @@ func TestAsyncWriterClosesOnResend(t *testing.T) {
 
 	writerImpl := newAsyncMockWriter()
 
-	w, err := NewAsyncWriter("foo", 1, writerImpl, component.NoopObservability())
+	w, err := NewAsyncWriter("foo", 1, false, writerImpl, component.NoopObservability())
 	if err != nil {
 		t.Error(err)
 		return
@@ -307,7 +307,7 @@ func TestAsyncWriterCanReconnect(t *testing.T) {
 
 	writerImpl := newAsyncMockWriter()
 
-	w, err := NewAsyncWriter("foo", 1, writerImpl, component.NoopObservability())
+	w, err := NewAsyncWriter("foo", 1, false, writerImpl, component.NoopObservability())
 	if err != nil {
 		t.Error(err)
 		return
@@ -375,7 +375,7 @@ func TestAsyncWriterCanReconnectAsync(t *testing.T) {
 
 	writerImpl := newAsyncMockWriter()
 
-	w, err := NewAsyncWriter("foo", 2, writerImpl, component.NoopObservability())
+	w, err := NewAsyncWriter("foo", 2, false, writerImpl, component.NoopObservability())
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -483,7 +483,7 @@ func TestAsyncWriterCantReconnect(t *testing.T) {
 
 	writerImpl := newAsyncMockWriter()
 
-	w, err := NewAsyncWriter("foo", 1, writerImpl, component.NoopObservability())
+	w, err := NewAsyncWriter("foo", 1, false, writerImpl, component.NoopObservability())
 	if err != nil {
 		t.Error(err)
 		return
@@ -546,7 +546,7 @@ func TestAsyncWriterHappyPath(t *testing.T) {
 
 	exp := [][]byte{[]byte("foo"), []byte("bar")}
 
-	w, err := NewAsyncWriter("foo", 1, writerImpl, component.NoopObservability())
+	w, err := NewAsyncWriter("foo", 1, false, writerImpl, component.NoopObservability())
 	if err != nil {
 		t.Error(err)
 		return
@@ -611,7 +611,7 @@ func TestAsyncWriterSadPath(t *testing.T) {
 	exp := [][]byte{[]byte("foo"), []byte("bar")}
 	expErr := errors.New("message got lost or something")
 
-	w, err := NewAsyncWriter("foo", 1, writerImpl, component.NoopObservability())
+	w, err := NewAsyncWriter("foo", 1, false, writerImpl, component.NoopObservability())
 	if err != nil {
 		t.Error(err)
 		return

--- a/internal/component/output/not_batched_test.go
+++ b/internal/component/output/not_batched_test.go
@@ -70,7 +70,7 @@ func TestNotBatchedSingleMessages(t *testing.T) {
 	}
 
 	w := &mockNBWriter{t: t}
-	out, err := NewAsyncWriter("foo", 1, w, component.NoopObservability())
+	out, err := NewAsyncWriter("foo", 1, false, w, component.NoopObservability())
 	require.NoError(t, err)
 
 	nbOut := OnlySinglePayloads(out)
@@ -113,7 +113,7 @@ func TestShutdown(t *testing.T) {
 	}
 
 	w := &mockNBWriter{t: t, closeChan: make(chan error)}
-	out, err := NewAsyncWriter("foo", 1, w, component.NoopObservability())
+	out, err := NewAsyncWriter("foo", 1, false, w, component.NoopObservability())
 	require.NoError(t, err)
 
 	nbOut := OnlySinglePayloads(out)
@@ -168,7 +168,7 @@ func TestNotBatchedBreakOutMessages(t *testing.T) {
 	}
 
 	w := &mockNBWriter{t: t}
-	out, err := NewAsyncWriter("foo", 1, w, component.NoopObservability())
+	out, err := NewAsyncWriter("foo", 1, false, w, component.NoopObservability())
 	require.NoError(t, err)
 
 	nbOut := OnlySinglePayloads(out)
@@ -213,7 +213,7 @@ func TestNotBatchedBreakOutMessagesErrors(t *testing.T) {
 	}
 
 	w := &mockNBWriter{t: t, errorOn: []string{"foo1", "foo3"}}
-	out, err := NewAsyncWriter("foo", 1, w, component.NoopObservability())
+	out, err := NewAsyncWriter("foo", 1, false, w, component.NoopObservability())
 	require.NoError(t, err)
 
 	nbOut := OnlySinglePayloads(out)
@@ -275,7 +275,7 @@ func TestNotBatchedBreakOutMessagesErrorsAsync(t *testing.T) {
 	}
 
 	w := &mockNBWriter{t: t, errorOn: []string{"foo1", "foo3"}}
-	out, err := NewAsyncWriter("foo", 5, w, component.NoopObservability())
+	out, err := NewAsyncWriter("foo", 5, false, w, component.NoopObservability())
 	require.NoError(t, err)
 
 	nbOut := OnlySinglePayloads(out)

--- a/internal/component/output/processors/append.go
+++ b/internal/component/output/processors/append.go
@@ -26,7 +26,7 @@ func AppendFromConfig(conf output.Config, mgr bundle.NewManagement, pipelines ..
 					return nil, err
 				}
 			}
-			return pipeline.NewProcessor(processors...), nil
+			return pipeline.NewProcessor(mgr.Strict(), processors...), nil
 		}}...)
 	}
 	return pipelines

--- a/internal/component/output/wrap_with_pipeline_test.go
+++ b/internal/component/output/wrap_with_pipeline_test.go
@@ -161,14 +161,14 @@ select_parts:
 			if err != nil {
 				return nil, err
 			}
-			return pipeline.NewProcessor(proc), nil
+			return pipeline.NewProcessor(false, proc), nil
 		},
 		func() (processor.Pipeline, error) {
 			proc, err := mock.NewManager().NewProcessor(secondProc)
 			if err != nil {
 				return nil, err
 			}
-			return pipeline.NewProcessor(proc), nil
+			return pipeline.NewProcessor(false, proc), nil
 		},
 	)
 	if err != nil {

--- a/internal/component/processor/execute.go
+++ b/internal/component/processor/execute.go
@@ -8,16 +8,43 @@ import (
 	"github.com/redpanda-data/benthos/v4/internal/message"
 )
 
+type strictCtxKey struct{}
+
+// WithStrict returns a child context that signals strict error handling to
+// ExecuteAll: a message that has failed a processing step skips the remaining
+// processors in the chain (rather than continuing through them with the error
+// flag set). The signal propagates to all nested ExecuteAll calls.
+func WithStrict(ctx context.Context) context.Context {
+	return context.WithValue(ctx, strictCtxKey{}, true)
+}
+
+// IsStrict returns true if the context carries the strict error handling signal.
+func IsStrict(ctx context.Context) bool {
+	v, _ := ctx.Value(strictCtxKey{}).(bool)
+	return v
+}
+
 // ExecuteAll attempts to execute a slice of processors to a message. Returns
 // N resulting messages or a response. The response may indicate either a NoAck
 // in the event of the message being buffered or an unrecoverable error.
+//
+// When the context carries the strict error handling signal (see WithStrict) a
+// message that has failed a processing step skips the remaining processors,
+// matching ExecuteTryAll's behaviour.
 func ExecuteAll(ctx context.Context, procs []V1, msgs ...message.Batch) ([]message.Batch, error) {
+	strict := IsStrict(ctx)
+
 	resultMsgs := make([]message.Batch, len(msgs))
 	copy(resultMsgs, msgs)
 
 	for i := 0; len(resultMsgs) > 0 && i < len(procs); i++ {
 		var nextResultMsgs []message.Batch
 		for _, m := range resultMsgs {
+			// In strict mode, skip messages that failed a prior stage.
+			if strict && len(m) > 0 && m.Get(0).ErrorGet() != nil {
+				nextResultMsgs = append(nextResultMsgs, m)
+				continue
+			}
 			rMsgs, err := procs[i].ProcessBatch(ctx, m)
 			if err != nil {
 				// We immediately return if a processor hits an unrecoverable

--- a/internal/component/processor/execute_strict_test.go
+++ b/internal/component/processor/execute_strict_test.go
@@ -1,0 +1,130 @@
+// Copyright 2026 Redpanda Data, Inc.
+
+package processor_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/redpanda-data/benthos/v4/internal/component/processor"
+	"github.com/redpanda-data/benthos/v4/internal/message"
+)
+
+// recordProc records the order in which it runs and optionally fails messages.
+type recordProc struct {
+	name string
+	ran  *[]string
+	fail bool
+}
+
+func (p recordProc) ProcessBatch(_ context.Context, b message.Batch) ([]message.Batch, error) {
+	*p.ran = append(*p.ran, p.name)
+	if p.fail {
+		_ = b.Iter(func(_ int, part *message.Part) error {
+			part.ErrorSet(errors.New(p.name + " failed"))
+			return nil
+		})
+	}
+	return []message.Batch{b}, nil
+}
+
+func (p recordProc) Close(context.Context) error { return nil }
+
+// strictProbe records whether the strict signal was present in the context it
+// was executed with.
+type strictProbe struct {
+	saw *bool
+}
+
+func (p strictProbe) ProcessBatch(ctx context.Context, b message.Batch) ([]message.Batch, error) {
+	*p.saw = processor.IsStrict(ctx)
+	return []message.Batch{b}, nil
+}
+
+func (p strictProbe) Close(context.Context) error { return nil }
+
+// Without the strict signal, ExecuteAll runs every processor even after one has
+// failed a message (mark-and-continue, the historical behaviour).
+func TestExecuteAllNonStrictRunsAll(t *testing.T) {
+	var ran []string
+	procs := []processor.V1{
+		recordProc{name: "a", ran: &ran, fail: true},
+		recordProc{name: "b", ran: &ran},
+	}
+	_, err := processor.ExecuteAll(context.Background(), procs, message.QuickBatch([][]byte{[]byte("x")}))
+	require.NoError(t, err)
+	assert.Equal(t, []string{"a", "b"}, ran)
+}
+
+// With the strict signal, a message that fails a processor skips the remaining
+// processors in the chain.
+func TestExecuteAllStrictShortCircuits(t *testing.T) {
+	var ran []string
+	procs := []processor.V1{
+		recordProc{name: "a", ran: &ran, fail: true},
+		recordProc{name: "b", ran: &ran},
+	}
+	_, err := processor.ExecuteAll(processor.WithStrict(context.Background()), procs, message.QuickBatch([][]byte{[]byte("x")}))
+	require.NoError(t, err)
+	assert.Equal(t, []string{"a"}, ran, "processor b must be skipped once a fails in strict mode")
+}
+
+// The strict signal propagates to nested ExecuteAll calls via the context.
+func TestExecuteAllStrictSignalVisible(t *testing.T) {
+	var saw bool
+	_, err := processor.ExecuteAll(processor.WithStrict(context.Background()), []processor.V1{strictProbe{saw: &saw}}, message.QuickBatch([][]byte{[]byte("x")}))
+	require.NoError(t, err)
+	assert.True(t, saw)
+}
+
+// --- Benchmarks: verify strict adds no material overhead to the hot path -----
+
+type noopProc struct{}
+
+func (noopProc) ProcessBatch(_ context.Context, b message.Batch) ([]message.Batch, error) {
+	return []message.Batch{b}, nil
+}
+func (noopProc) Close(context.Context) error { return nil }
+
+func benchExecuteAll(b *testing.B, ctx context.Context) {
+	b.Helper()
+	procs := []processor.V1{noopProc{}, noopProc{}, noopProc{}}
+	msg := message.QuickBatch([][]byte{[]byte("hello world")})
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if _, err := processor.ExecuteAll(ctx, procs, msg); err != nil {
+			b.Fatal(err)
+		}
+	}
+}
+
+// The default (non-strict) path: this is what every existing pipeline pays. The
+// only added cost over the historical implementation is a single IsStrict(ctx)
+// lookup per call.
+func BenchmarkExecuteAllNonStrict(b *testing.B) {
+	// Mirror the pipeline's context shape (a cancel context over Background).
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	benchExecuteAll(b, ctx)
+}
+
+func BenchmarkExecuteAllStrict(b *testing.B) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	benchExecuteAll(b, processor.WithStrict(ctx))
+}
+
+func BenchmarkIsStrict(b *testing.B) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	b.ReportAllocs()
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		_ = processor.IsStrict(ctx)
+	}
+}

--- a/internal/config/lint.go
+++ b/internal/config/lint.go
@@ -52,6 +52,7 @@ func (r *Reader) ReadYAMLFileLinted(ctx context.Context, spec docs.FieldSpecs, p
 
 	if !bytes.HasPrefix(configBytes, []byte("# BENTHOS LINT DISABLE")) {
 		lints = append(lints, spec.LintYAML(docs.NewLintContext(lConf), cNode)...)
+		lints = append(lints, lintStrictErrorHandling(conf, cNode, lConf.DocsProvider)...)
 	}
 	return conf, lints, nil
 }

--- a/internal/config/lint_strict.go
+++ b/internal/config/lint_strict.go
@@ -1,0 +1,45 @@
+// Copyright 2026 Redpanda Data, Inc.
+
+package config
+
+import (
+	"gopkg.in/yaml.v3"
+
+	"github.com/redpanda-data/benthos/v4/internal/docs"
+)
+
+const strictCatchLintMsg = "a `catch` processor does not recover messages while `error_handling.strict` is enabled, as a failed message short-circuits past it. Wrap the failing step and its recovery within a `try_catch` processor (or a `retry` for transient failures) instead."
+
+// lintStrictErrorHandling warns about configuration that will silently stop
+// handling errors once strict error handling is enabled.
+//
+// Under strict mode a failed message short-circuits the remaining processors in
+// its chain, so a standalone `catch` processor — a downstream catcher of an
+// upstream failure — is skipped and never recovers anything. There is no longer
+// any scope in which a legacy `catch` observes a failed message: a `try_catch`
+// clears the failure flag (moving the error into metadata) before running its
+// `catch` block, and every other composition processor that runs children also
+// either short-circuits or starts them unflagged. Recovery is therefore done
+// exclusively with `try_catch`/`retry`, and any `catch` processor (at any
+// nesting depth) is reported when strict is enabled.
+func lintStrictErrorHandling(conf Type, node *yaml.Node, prov docs.Provider) []docs.Lint {
+	if !conf.ErrorHandling.Strict || node == nil {
+		return nil
+	}
+
+	var lints []docs.Lint
+	walkConf := docs.WalkComponentConfig{
+		Provider: prov,
+		Func: func(c docs.WalkedComponent) error {
+			if c.Name == "catch" {
+				lints = append(lints, docs.NewLintWarning(c.LineStart, docs.LintCustom, strictCatchLintMsg))
+			}
+			return nil
+		},
+	}
+
+	// A structurally invalid config would already have failed to parse before
+	// this point; if the walk still errors we skip the rule rather than fail.
+	_ = Spec().WalkComponentsYAML(walkConf, node)
+	return lints
+}

--- a/internal/config/lint_strict_test.go
+++ b/internal/config/lint_strict_test.go
@@ -1,0 +1,180 @@
+// Copyright 2026 Redpanda Data, Inc.
+
+package config_test
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/redpanda-data/benthos/v4/internal/bundle"
+	"github.com/redpanda-data/benthos/v4/internal/config"
+	"github.com/redpanda-data/benthos/v4/internal/docs"
+
+	_ "github.com/redpanda-data/benthos/v4/public/components/pure"
+)
+
+// strictCatchLints runs the full linted read over a config and returns only the
+// strict-catch warnings, isolating them from any incidental lints.
+func strictCatchLints(t *testing.T, conf string) []docs.Lint {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	require.NoError(t, os.WriteFile(path, []byte(conf), 0o644))
+
+	rdr := config.NewReader(path, nil)
+	_, lints, err := rdr.ReadYAMLFileLinted(context.Background(), config.Spec(), path, false, docs.NewLintConfig(bundle.GlobalEnvironment))
+	require.NoError(t, err)
+
+	var out []docs.Lint
+	for _, l := range lints {
+		if strings.Contains(l.What, "error_handling.strict") {
+			out = append(out, l)
+		}
+	}
+	return out
+}
+
+func TestLintStrictCatchInPipeline(t *testing.T) {
+	lints := strictCatchLints(t, `
+error_handling:
+  strict: true
+input:
+  generate:
+    mapping: 'root = {}'
+    count: 1
+output:
+  drop: {}
+pipeline:
+  processors:
+    - mapping: 'root = this'
+    - catch: []
+`)
+	require.Len(t, lints, 1)
+	assert.Equal(t, docs.LintWarning, lints[0].Level)
+	assert.Contains(t, lints[0].What, "try_catch")
+	assert.Greater(t, lints[0].Line, 0, "the lint should carry the line of the catch processor")
+}
+
+func TestLintStrictCatchInInputAndOutput(t *testing.T) {
+	lints := strictCatchLints(t, `
+error_handling:
+  strict: true
+input:
+  generate:
+    mapping: 'root = {}'
+    count: 1
+  processors:
+    - catch: []
+output:
+  drop: {}
+  processors:
+    - catch: []
+`)
+	assert.Len(t, lints, 2, "a catch in both input and output processors should each warn")
+}
+
+func TestLintStrictDisabledNoWarning(t *testing.T) {
+	lints := strictCatchLints(t, `
+input:
+  generate:
+    mapping: 'root = {}'
+    count: 1
+output:
+  drop: {}
+pipeline:
+  processors:
+    - catch: []
+`)
+	assert.Empty(t, lints)
+}
+
+// try_catch is the recommended recovery scope under strict and must not warn.
+func TestLintStrictTryCatchNotFlagged(t *testing.T) {
+	lints := strictCatchLints(t, `
+error_handling:
+  strict: true
+input:
+  generate:
+    mapping: 'root = {}'
+    count: 1
+output:
+  drop: {}
+pipeline:
+  processors:
+    - try_catch:
+        processors:
+          - mapping: 'root = this'
+        catch:
+          - mapping: 'root = "recovered"'
+`)
+	assert.Empty(t, lints)
+}
+
+// A catch nested inside a switch case is still dead under strict and must warn.
+func TestLintStrictCatchNestedInSwitch(t *testing.T) {
+	lints := strictCatchLints(t, `
+error_handling:
+  strict: true
+input:
+  generate:
+    mapping: 'root = {}'
+    count: 1
+output:
+  drop: {}
+pipeline:
+  processors:
+    - switch:
+        - processors:
+            - catch: []
+`)
+	require.Len(t, lints, 1)
+	assert.Greater(t, lints[0].Line, 0)
+}
+
+// Under the metadata-based try_catch model, a catch processor is dead at every
+// position under strict — including within a try_catch's `catch` field, which
+// runs on messages whose failure flag has already been cleared. Both catches
+// warn.
+func TestLintStrictCatchNestedInTryCatch(t *testing.T) {
+	lints := strictCatchLints(t, `
+error_handling:
+  strict: true
+input:
+  generate:
+    mapping: 'root = {}'
+    count: 1
+output:
+  drop: {}
+pipeline:
+  processors:
+    - try_catch:
+        processors:
+          - catch: []
+        catch:
+          - catch: []
+`)
+	require.Len(t, lints, 2, "a catch processor is dead under strict at any position, including within a try_catch catch block")
+}
+
+func TestLintStrictNoCatchNoWarning(t *testing.T) {
+	lints := strictCatchLints(t, `
+error_handling:
+  strict: true
+input:
+  generate:
+    mapping: 'root = {}'
+    count: 1
+output:
+  drop: {}
+pipeline:
+  processors:
+    - mapping: 'root = this'
+`)
+	assert.Empty(t, lints)
+}

--- a/internal/config/schema.go
+++ b/internal/config/schema.go
@@ -22,7 +22,15 @@ const (
 	fieldSystemCloseDelay   = "shutdown_delay"
 	fieldSystemCloseTimeout = "shutdown_timeout"
 	fieldTests              = "tests"
+
+	fieldErrorHandling       = "error_handling"
+	fieldErrorHandlingStrict = "strict"
 )
+
+// ErrorHandlingConfig describes engine-wide error handling behaviour.
+type ErrorHandlingConfig struct {
+	Strict bool `yaml:"strict"`
+}
 
 // Type is the Benthos service configuration struct.
 type Type struct {
@@ -35,6 +43,8 @@ type Type struct {
 	SystemCloseDelay       string         `yaml:"shutdown_delay"`
 	SystemCloseTimeout     string         `yaml:"shutdown_timeout"`
 	Tests                  []any          `yaml:"tests"`
+
+	ErrorHandling ErrorHandlingConfig `yaml:"error_handling"`
 
 	rawSource any
 }
@@ -64,6 +74,9 @@ func observabilityFields() docs.FieldSpecs {
 		}),
 		docs.FieldString(fieldSystemCloseDelay, "A period of time to wait for metrics and traces to be pulled or pushed from the process.").HasDefault("0s"),
 		docs.FieldString(fieldSystemCloseTimeout, "The maximum period of time to wait for a clean shutdown. If this time is exceeded Redpanda Connect will forcefully close.").HasDefault("20s"),
+		docs.FieldObject(fieldErrorHandling, "Configures engine-wide error handling behaviour.").WithChildren(
+			docs.FieldBool(fieldErrorHandlingStrict, "When enabled, a processing error is terminal for the affected message: it skips the remaining processors in its pipeline and is rejected (nacked) at the output rather than written. To recover from an expected error, wrap the fallible step within a `try_catch` processor (or a `retry` processor for transient failures); a standalone `catch` does not recover messages under this mode, as the failed message short-circuits past it. This setting will become the default and only behaviour in the next major version.").HasDefault(false),
+		).Advanced(),
 	}
 }
 
@@ -145,6 +158,11 @@ func noStreamFromParsed(prov docs.Provider, pConf *docs.ParsedConfig, conf *Type
 	}
 	if pConf.Contains(fieldSystemCloseTimeout) {
 		if conf.SystemCloseTimeout, err = pConf.FieldString(fieldSystemCloseTimeout); err != nil {
+			return
+		}
+	}
+	if pConf.Contains(fieldErrorHandling, fieldErrorHandlingStrict) {
+		if conf.ErrorHandling.Strict, err = pConf.FieldBool(fieldErrorHandling, fieldErrorHandlingStrict); err != nil {
 			return
 		}
 	}

--- a/internal/config/strict_test.go
+++ b/internal/config/strict_test.go
@@ -1,0 +1,38 @@
+// Copyright 2026 Redpanda Data, Inc.
+
+package config_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/redpanda-data/benthos/v4/internal/bundle"
+	"github.com/redpanda-data/benthos/v4/internal/config"
+)
+
+func TestConfigErrorHandlingStrict(t *testing.T) {
+	spec := config.Spec()
+
+	parse := func(t *testing.T, raw map[string]any) config.Type {
+		t.Helper()
+		pConf, err := spec.ParsedConfigFromAny(raw)
+		require.NoError(t, err)
+		c, err := config.FromParsed(bundle.GlobalEnvironment, pConf, nil)
+		require.NoError(t, err)
+		return c
+	}
+
+	t.Run("defaults off", func(t *testing.T) {
+		c := parse(t, map[string]any{})
+		assert.False(t, c.ErrorHandling.Strict)
+	})
+
+	t.Run("enabled", func(t *testing.T) {
+		c := parse(t, map[string]any{
+			"error_handling": map[string]any{"strict": true},
+		})
+		assert.True(t, c.ErrorHandling.Strict)
+	})
+}

--- a/internal/impl/io/output_websocket.go
+++ b/internal/impl/io/output_websocket.go
@@ -49,7 +49,7 @@ func init() {
 				return
 			}
 			var o output.Streamed
-			if o, err = output.NewAsyncWriter("websocket", 1, w, oldMgr); err != nil {
+			if o, err = output.NewAsyncWriter("websocket", 1, oldMgr.Strict(), w, oldMgr); err != nil {
 				return
 			}
 			out = interop.NewUnwrapInternalOutput(o)

--- a/internal/impl/pure/output_cache.go
+++ b/internal/impl/pure/output_cache.go
@@ -88,7 +88,7 @@ func init() {
 			}
 
 			var s output.Streamed
-			if s, err = output.NewAsyncWriter("cache", maxInFlight, ca, mgr); err != nil {
+			if s, err = output.NewAsyncWriter("cache", maxInFlight, mgr.Strict(), ca, mgr); err != nil {
 				return
 			}
 			out = interop.NewUnwrapInternalOutput(s)

--- a/internal/impl/pure/output_drop.go
+++ b/internal/impl/pure/output_drop.go
@@ -22,7 +22,7 @@ func init() {
 		func(conf *service.ParsedConfig, res *service.Resources) (out service.BatchOutput, batchPolicy service.BatchPolicy, maxInFlight int, err error) {
 			nm := interop.UnwrapManagement(res)
 			var o output.Streamed
-			if o, err = output.NewAsyncWriter("drop", 1, newDropWriter(nm), nm); err != nil {
+			if o, err = output.NewAsyncWriter("drop", 1, false, newDropWriter(nm), nm); err != nil {
 				return
 			}
 			out = interop.NewUnwrapInternalOutput(o)

--- a/internal/impl/pure/output_reject.go
+++ b/internal/impl/pure/output_reject.go
@@ -60,7 +60,7 @@ output:
 			}
 
 			var s output.Streamed
-			if s, err = output.NewAsyncWriter("reject", 1, w, mgr); err != nil {
+			if s, err = output.NewAsyncWriter("reject", 1, false, w, mgr); err != nil {
 				return
 			}
 			out = interop.NewUnwrapInternalOutput(s)

--- a/internal/impl/pure/output_sync_response.go
+++ b/internal/impl/pure/output_sync_response.go
@@ -46,7 +46,7 @@ For more information please read xref:guides:sync_responses.adoc[synchronous res
 			Field(service.NewObjectField("").Default(map[string]any{})),
 		func(conf *service.ParsedConfig, mgr *service.Resources) (out service.BatchOutput, batchPolicy service.BatchPolicy, maxInFlight int, err error) {
 			var s output.Streamed
-			if s, err = output.NewAsyncWriter("sync_response", 1, SyncResponseWriter{o: interop.UnwrapManagement(mgr)}, interop.UnwrapManagement(mgr)); err != nil {
+			if s, err = output.NewAsyncWriter("sync_response", 1, false, SyncResponseWriter{o: interop.UnwrapManagement(mgr)}, interop.UnwrapManagement(mgr)); err != nil {
 				return
 			}
 			out = interop.NewUnwrapInternalOutput(s)

--- a/internal/impl/pure/processor_catch.go
+++ b/internal/impl/pure/processor_catch.go
@@ -34,6 +34,8 @@ If the processor `+"`foo`"+` fails for a particular message, that message will b
 
 When messages leave the catch block their fail flags are cleared. This processor is useful for when it's possible to recover failed messages, or when special actions (such as logging/metrics) are required before dropping them.
 
+NOTE: When strict error handling (`+"`error_handling.strict`"+`) is enabled this processor does not recover anything, as a failed message short-circuits past it rather than reaching it. Use the xref:components:processors/try_catch.adoc[`+"`try_catch`"+`] processor instead, which contains both the fallible step and its recovery.
+
 More information about error handling can be found in xref:configuration:error_handling.adoc[].`).
 		LintRule(`if this.or([]).any(pconf -> pconf.type.or("") == "try" || pconf.try.type() == "array" ) {
   "'catch' block contains a 'try' block which will never execute due to errors only being cleared at the end of the 'catch', for more information about nesting 'try' within 'catch' read: https://docs.redpanda.com/redpanda-connect/components/processors/try#nesting-within-a-catch-block"

--- a/internal/impl/pure/processor_strict_test.go
+++ b/internal/impl/pure/processor_strict_test.go
@@ -1,0 +1,236 @@
+// Copyright 2026 Redpanda Data, Inc.
+
+package pure_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/redpanda-data/benthos/v4/internal/component/processor"
+	"github.com/redpanda-data/benthos/v4/internal/component/testutil"
+	"github.com/redpanda-data/benthos/v4/internal/manager/mock"
+	"github.com/redpanda-data/benthos/v4/internal/message"
+
+	_ "github.com/redpanda-data/benthos/v4/internal/impl/pure"
+)
+
+func mustProc(t *testing.T, conf string) processor.V1 {
+	t.Helper()
+	pConf, err := testutil.ProcessorFromYAML(conf)
+	require.NoError(t, err)
+	p, err := mock.NewManager().NewProcessor(pConf)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = p.Close(t.Context()) })
+	return p
+}
+
+func strictExec(t *testing.T, procs []processor.V1, in string) message.Batch {
+	t.Helper()
+	msgs, err := processor.ExecuteAll(processor.WithStrict(t.Context()), procs, message.QuickBatch([][]byte{[]byte(in)}))
+	require.NoError(t, err)
+	require.Len(t, msgs, 1)
+	return msgs[0]
+}
+
+// Under strict execution, a message that fails a processor skips the remaining
+// processors and retains its error (which would be rejected at the output).
+func TestStrictPipelineShortCircuitsUnrecovered(t *testing.T) {
+	out := strictExec(t, []processor.V1{
+		mustProc(t, `mapping: 'root = throw("boom")'`),
+		mustProc(t, `mapping: 'root = "reached"'`),
+	}, "x")
+
+	require.Equal(t, 1, out.Len())
+	assert.Equal(t, "x", string(out.Get(0).AsBytes()), "the second processor must be skipped")
+	assert.Error(t, out.Get(0).ErrorGet(), "the unrecovered error survives to be rejected at the output")
+}
+
+// A standalone `catch` processor does NOT recover a prior failure under strict:
+// the errored message short-circuits past it (catch is a downstream catcher, not
+// a wrapper that contains the failure). This is a deliberate design decision —
+// under strict, recovery is done with try_catch (or retry). Documented so the
+// behaviour is locked and not "fixed" by accident.
+func TestStrictStandaloneCatchDoesNotRecover(t *testing.T) {
+	out := strictExec(t, []processor.V1{
+		mustProc(t, `mapping: 'root = throw("boom")'`),
+		mustProc(t, `
+catch:
+  - mapping: 'root = "RECOVERED"'
+`),
+	}, "x")
+
+	require.Equal(t, 1, out.Len())
+	assert.Equal(t, "x", string(out.Get(0).AsBytes()), "standalone catch must be skipped, not recover the message")
+	assert.Error(t, out.Get(0).ErrorGet(), "the message remains errored and would be rejected at the output")
+}
+
+// A new error introduced inside a catch block is preserved (not swallowed by the
+// strict-stripping of the catch scope): the message leaves the try_catch still
+// errored and would therefore be rejected at the output under strict. Strict's
+// reject applies at the output regardless of the catch scope's short-circuit
+// exemption.
+func TestStrictNewErrorInCatchIsPreserved(t *testing.T) {
+	out := strictExec(t, []processor.V1{
+		mustProc(t, `
+try_catch:
+  processors:
+    - mapping: 'root = throw("original")'
+  catch:
+    - mapping: 'root = throw("new error in catch")'
+`),
+	}, "x")
+
+	require.Equal(t, 1, out.Len())
+	err := out.Get(0).ErrorGet()
+	require.Error(t, err, "a new error raised inside the catch block must survive to be rejected at the output")
+	assert.Contains(t, err.Error(), "new error in catch")
+}
+
+// Within a try_catch catch block the failure flag is cleared before the catch
+// processors run, so they execute under strict semantics: a NEW error raised by
+// an early catch processor short-circuits the subsequent ones, and the surviving
+// error is retained for output rejection.
+func TestStrictCatchBlockShortCircuitsNewErrors(t *testing.T) {
+	out := strictExec(t, []processor.V1{
+		mustProc(t, `
+try_catch:
+  processors:
+    - mapping: 'root = throw("original")'
+  catch:
+    - mapping: 'root = throw("first catch step fails")'
+    - mapping: 'meta ran_second = "yes"'
+`),
+	}, "x")
+
+	require.Equal(t, 1, out.Len())
+	assert.NotEqual(t, "yes", out.Get(0).MetaGetStr("ran_second"), "a new error in the catch block short-circuits later catch processors under strict")
+	assert.Error(t, out.Get(0).ErrorGet(), "the surviving error is retained for output rejection")
+}
+
+// A try_catch that recovers a failure clears the error, so subsequent processors
+// run normally and the message is not rejected.
+func TestStrictPipelineTryCatchRecovers(t *testing.T) {
+	out := strictExec(t, []processor.V1{
+		mustProc(t, `
+try_catch:
+  processors:
+    - mapping: 'root = throw("boom")'
+  catch:
+    - mapping: 'root = "recovered"'
+`),
+		mustProc(t, `mapping: 'root = content().string() + "-reached"'`),
+	}, "x")
+
+	require.Equal(t, 1, out.Len())
+	assert.Equal(t, "recovered-reached", string(out.Get(0).AsBytes()), "recovery clears the error so later processors run")
+	assert.NoError(t, out.Get(0).ErrorGet())
+}
+
+// A non-recovering catch leaves the message failed, so it short-circuits and is
+// rejected — confirming only genuinely-handled errors are cleared.
+func TestStrictPipelineFailingCatchStillShortCircuits(t *testing.T) {
+	out := strictExec(t, []processor.V1{
+		mustProc(t, `
+try_catch:
+  processors:
+    - mapping: 'root = throw("boom")'
+  catch:
+    - mapping: 'root = throw("catch failed too")'
+`),
+		mustProc(t, `mapping: 'root = "reached"'`),
+	}, "x")
+
+	require.Equal(t, 1, out.Len())
+	assert.NotEqual(t, "reached", string(out.Get(0).AsBytes()), "a failed recovery still short-circuits")
+	assert.Error(t, out.Get(0).ErrorGet())
+}
+
+// branch manipulates the error flag itself; under strict its children
+// short-circuit, but it must still behave correctly (D7 verification).
+func TestStrictBranchDoesNotBreak(t *testing.T) {
+	// A branch whose child fails maps the error back onto the message.
+	out := strictExec(t, []processor.V1{
+		mustProc(t, `
+branch:
+  processors:
+    - mapping: 'root = throw("branch child boom")'
+`),
+	}, "x")
+	require.Equal(t, 1, out.Len())
+	assert.Error(t, out.Get(0).ErrorGet(), "branch maps the child failure back onto the message")
+
+	// A branch whose child succeeds works normally under strict.
+	out = strictExec(t, []processor.V1{
+		mustProc(t, `
+branch:
+  request_map: 'root = this'
+  processors:
+    - mapping: 'root.added = "yes"'
+  result_map: 'root.added = this.added'
+`),
+	}, `{"id":1}`)
+	require.Equal(t, 1, out.Len())
+	assert.NoError(t, out.Get(0).ErrorGet())
+	assert.JSONEq(t, `{"id":1,"added":"yes"}`, string(out.Get(0).AsBytes()))
+}
+
+// while runs its children in a loop; under strict a child failure short-circuits
+// without breaking the processor (D7 verification).
+func TestStrictWhileDoesNotBreak(t *testing.T) {
+	out := strictExec(t, []processor.V1{
+		mustProc(t, `
+while:
+  at_least_once: true
+  check: 'false'
+  processors:
+    - mapping: 'root = throw("while child boom")'
+`),
+	}, "x")
+	require.Equal(t, 1, out.Len())
+	assert.Error(t, out.Get(0).ErrorGet())
+}
+
+// Short-circuit must fire INSIDE composition processors (not just at the top
+// level) — verifying the strict signal propagates through their child chains.
+func TestStrictShortCircuitsInsideForEach(t *testing.T) {
+	out := strictExec(t, []processor.V1{
+		mustProc(t, `
+for_each:
+  - mapping: 'root = throw("boom")'
+  - mapping: 'root = "reached"'
+`),
+	}, "x")
+	require.Equal(t, 1, out.Len())
+	assert.Equal(t, "x", string(out.Get(0).AsBytes()), "for_each child after the failure must be skipped")
+	assert.Error(t, out.Get(0).ErrorGet())
+}
+
+func TestStrictShortCircuitsInsideSwitchCase(t *testing.T) {
+	out := strictExec(t, []processor.V1{
+		mustProc(t, `
+switch:
+  - processors:
+      - mapping: 'root = throw("boom")'
+      - mapping: 'root = "reached"'
+`),
+	}, "x")
+	require.Equal(t, 1, out.Len())
+	assert.Equal(t, "x", string(out.Get(0).AsBytes()), "switch-case child after the failure must be skipped")
+	assert.Error(t, out.Get(0).ErrorGet())
+}
+
+// Filtering (deleting) a message is NOT an error: under strict the survivors
+// continue through the pipeline and nothing is rejected.
+func TestStrictDoesNotRejectFilteredMessages(t *testing.T) {
+	msgs, err := processor.ExecuteAll(processor.WithStrict(t.Context()), []processor.V1{
+		mustProc(t, `mapping: 'root = if content().string() == "drop" { deleted() }'`),
+		mustProc(t, `mapping: 'root = content().string() + "-kept"'`),
+	}, message.QuickBatch([][]byte{[]byte("drop"), []byte("keep")}))
+	require.NoError(t, err)
+	require.Len(t, msgs, 1)
+	require.Equal(t, 1, msgs[0].Len(), "the filtered message is gone, the survivor remains")
+	assert.Equal(t, "keep-kept", string(msgs[0].Get(0).AsBytes()))
+	assert.NoError(t, msgs[0].Get(0).ErrorGet())
+}

--- a/internal/impl/pure/processor_try_catch.go
+++ b/internal/impl/pure/processor_try_catch.go
@@ -1,0 +1,206 @@
+// Copyright 2026 Redpanda Data, Inc.
+
+package pure
+
+import (
+	"context"
+	"errors"
+
+	"github.com/redpanda-data/benthos/v4/internal/bloblang/query"
+	"github.com/redpanda-data/benthos/v4/internal/component/interop"
+	"github.com/redpanda-data/benthos/v4/internal/component/processor"
+	"github.com/redpanda-data/benthos/v4/internal/message"
+	"github.com/redpanda-data/benthos/v4/public/service"
+)
+
+const (
+	tcFieldProcessors  = "processors"
+	tcFieldCatch       = "catch"
+	tcFieldErrorMeta   = "error_metadata"
+	tcDefaultErrorMeta = "error"
+)
+
+func init() {
+	service.MustRegisterBatchProcessor("try_catch", service.NewConfigSpec().
+		Beta().
+		Categories("Composition").
+		Summary("Executes a list of child `processors` on each message and, if any of them fail, executes a separate list of `catch` processors to recover from or react to the error.").
+		Description(`
+This processor combines the behaviour of the `+"xref:components:processors/try.adoc[`try`]"+` and xref:components:processors/catch.adoc[`+"`catch`"+`] processors into a single block with an explicit recovery path. Because it contains both the fallible step and its recovery within a single processor, it is the recommended way to handle expected errors when strict error handling (`+"`error_handling.strict`"+`) is enabled.
+
+Each message of a batch is processed individually. The `+"`processors`"+` field is executed with "try" semantics: as soon as a processor fails for a given message the remaining `+"`processors`"+` are skipped for that message.
+
+Any message that failed is then routed to the `+"`catch`"+` processors. Before they run, the failure is moved off the message: it is stored as a structured object in a metadata field (see `+"`error_metadata`"+`, `+"`error`"+` by default) and the message's failure flag is **cleared**. The error is therefore available to recovery logic as an ordinary variable rather than as a message property. The object contains:
+
+- `+"`what`"+`: the error message.
+- `+"`name`"+`: the name of the component that failed (when known).
+- `+"`label`"+`: the label of the component that failed (when set).
+- `+"`path`"+`: the dot-path of the component that failed (when known).
+
+So a recovery mapping reads the failure with, for example, `+"`@error.what`"+` (equivalent to `+"`meta(\"error\").what`"+`). Because the flag is cleared, the `+"`catch`"+` processors run under the normal error semantics — including strict — so a _new_ failure raised while recovering is treated as a fresh error and is not silently tolerated.
+
+Note that because the failure flag is cleared before the `+"`catch`"+` processors run, the xref:guides:bloblang/functions.adoc#error[`+"`error`"+`] and `+"`error_source_*`"+` functions do not report the original failure within the `+"`catch`"+` block; use the metadata object instead. An empty or omitted `+"`catch`"+` simply records the error in metadata and clears the flag (the failure is swallowed).
+
+`+"```yaml"+`
+pipeline:
+  processors:
+    - try_catch:
+        processors:
+          - resource: foo
+          - resource: bar
+        catch:
+          - mutation: 'root = "failed to process: " + @error.what'
+`+"```"+`
+
+In the example above, if either `+"`foo` or `bar`"+` fails for a message then the `+"`mutation`"+` is applied to that message, replacing its contents with a description of the error (read from the metadata object), and the message continues downstream without a failure flag.
+
+More information about error handling can be found in xref:configuration:error_handling.adoc[].`).
+		Field(service.NewProcessorListField(tcFieldProcessors).
+			Description("A list of processors to execute on each message. If a processor fails for a given message the remaining processors in this list are skipped for that message, and the message is routed to the `catch` processors.").
+			Default([]any{})).
+		Field(service.NewProcessorListField(tcFieldCatch).
+			Description("A list of processors to execute on each message that failed one of the `processors` above. The message is no longer flagged as failed when these run; the error is available as an object in the metadata field named by `error_metadata` (e.g. `@error.what`). When omitted or empty the error is recorded in metadata and the flag is cleared (the failure is swallowed).").
+			Default([]any{})).
+		Field(service.NewStringField(tcFieldErrorMeta).
+			Description("The metadata key under which the caught error is stored, as an object with a `what` field (the error message) plus `name`, `label` and `path` fields describing the component that failed, before the `catch` processors are executed.").
+			Default(tcDefaultErrorMeta)),
+		func(conf *service.ParsedConfig, res *service.Resources) (service.BatchProcessor, error) {
+			mgr := interop.UnwrapManagement(res)
+
+			pubProcs, err := conf.FieldProcessorList(tcFieldProcessors)
+			if err != nil {
+				return nil, err
+			}
+			pubCatch, err := conf.FieldProcessorList(tcFieldCatch)
+			if err != nil {
+				return nil, err
+			}
+			errorMeta, err := conf.FieldString(tcFieldErrorMeta)
+			if err != nil {
+				return nil, err
+			}
+
+			procs := make([]processor.V1, len(pubProcs))
+			for i, p := range pubProcs {
+				procs[i] = interop.UnwrapOwnedProcessor(p)
+			}
+			catch := make([]processor.V1, len(pubCatch))
+			for i, p := range pubCatch {
+				catch[i] = interop.UnwrapOwnedProcessor(p)
+			}
+
+			p := processor.NewAutoObservedBatchedProcessor("try_catch", newTryCatchProc(procs, catch, errorMeta), mgr)
+			return interop.NewUnwrapInternalBatchProcessor(p), nil
+		})
+}
+
+type tryCatchProc struct {
+	processors []processor.V1
+	catch      []processor.V1
+	errorMeta  string
+}
+
+func newTryCatchProc(processors, catch []processor.V1, errorMeta string) *tryCatchProc {
+	return &tryCatchProc{
+		processors: processors,
+		catch:      catch,
+		errorMeta:  errorMeta,
+	}
+}
+
+// errorToObject builds the structured metadata value describing a caught
+// failure. The `what` field always holds the error message. When the failure
+// originated from a component (a *query.ComponentError, the usual case) the
+// source `name`, `label` and `path` are also included, mirroring the
+// error_source_name/label/path Bloblang functions.
+func errorToObject(err error) map[string]any {
+	obj := map[string]any{"what": err.Error()}
+	var cErr *query.ComponentError
+	if errors.As(err, &cErr) {
+		obj["name"] = cErr.Name
+		obj["label"] = cErr.Label
+		obj["path"] = query.SliceToDotPath(cErr.Path...)
+	}
+	return obj
+}
+
+func (p *tryCatchProc) ProcessBatch(ctx *processor.BatchProcContext, msg message.Batch) ([]message.Batch, error) {
+	// Operate on each message individually so that a failure in one does not
+	// short-circuit processing of the others.
+	resultMsgs := make([]message.Batch, msg.Len())
+	_ = msg.Iter(func(i int, part *message.Part) error {
+		resultMsgs[i] = message.Batch{part}
+		return nil
+	})
+
+	// Execute the primary processors with "try" semantics: once a message fails
+	// a step the remaining steps are skipped for that message.
+	var err error
+	if resultMsgs, err = processor.ExecuteTryAll(ctx.Context(), p.processors, resultMsgs...); err != nil {
+		return nil, err
+	}
+
+	// For each message that failed, move the error into metadata and clear the
+	// failure flag, then run the catch processors on it as an ordinary message.
+	// Because the message is no longer flagged, the catch processors execute
+	// under the ambient (including strict) error semantics: a new failure raised
+	// during recovery is treated as a fresh error rather than being tolerated.
+	var nextResultMsgs []message.Batch
+	for _, m := range resultMsgs {
+		if len(m) == 0 {
+			continue
+		}
+		// Matches the try/catch convention of treating the first message of a
+		// resulting batch as representative of its failure state.
+		if m.Get(0).ErrorGet() == nil {
+			nextResultMsgs = append(nextResultMsgs, m)
+			continue
+		}
+
+		_ = m.Iter(func(_ int, part *message.Part) error {
+			if e := part.ErrorGet(); e != nil {
+				part.MetaSetMut(p.errorMeta, errorToObject(e))
+				part.ErrorSet(nil)
+			}
+			return nil
+		})
+
+		if len(p.catch) == 0 {
+			nextResultMsgs = append(nextResultMsgs, m)
+			continue
+		}
+
+		caughtMsgs, cerr := processor.ExecuteAll(ctx.Context(), p.catch, m)
+		if cerr != nil {
+			return nil, cerr
+		}
+		nextResultMsgs = append(nextResultMsgs, caughtMsgs...)
+	}
+
+	resMsg := message.QuickBatch(nil)
+	for _, m := range nextResultMsgs {
+		_ = m.Iter(func(i int, part *message.Part) error {
+			resMsg = append(resMsg, part)
+			return nil
+		})
+	}
+	if resMsg.Len() == 0 {
+		return nil, nil
+	}
+
+	return []message.Batch{resMsg}, nil
+}
+
+func (p *tryCatchProc) Close(ctx context.Context) error {
+	for _, c := range p.processors {
+		if err := c.Close(ctx); err != nil {
+			return err
+		}
+	}
+	for _, c := range p.catch {
+		if err := c.Close(ctx); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/internal/impl/pure/processor_try_catch_internal_test.go
+++ b/internal/impl/pure/processor_try_catch_internal_test.go
@@ -1,0 +1,102 @@
+// Copyright 2026 Redpanda Data, Inc.
+
+package pure
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/redpanda-data/benthos/v4/internal/component/processor"
+	"github.com/redpanda-data/benthos/v4/internal/component/testutil"
+	"github.com/redpanda-data/benthos/v4/internal/manager/mock"
+	"github.com/redpanda-data/benthos/v4/internal/message"
+)
+
+// --- Benchmarks -------------------------------------------------------------
+//
+// These characterise the cost of adopting try_catch on the success path (no
+// failures), against two reference points:
+//
+//   - bare_series: the same processors run as an ordinary in-order pipeline
+//     (processor.ExecuteAll) with NO per-message error isolation. The floor.
+//   - try_then_catch: the real `try` + `catch` processor composition that
+//     try_catch replaces. Like try_catch, these isolate errors per message, so
+//     this is the apples-to-apples comparison.
+
+func benchProc(tb testing.TB, conf string) processor.V1 {
+	tb.Helper()
+	c, err := testutil.ProcessorFromYAML(conf)
+	require.NoError(tb, err)
+	p, err := mock.NewManager().NewProcessor(c)
+	require.NoError(tb, err)
+	return p
+}
+
+func benchMappingProcs(tb testing.TB, n int) []processor.V1 {
+	tb.Helper()
+	procs := make([]processor.V1, n)
+	for i := range procs {
+		procs[i] = benchProc(tb, `mapping: 'root = content().uppercase()'`)
+	}
+	return procs
+}
+
+func benchBatch(n int) message.Batch {
+	parts := make([][]byte, n)
+	for i := range parts {
+		parts[i] = []byte("the quick brown fox jumps over the lazy dog")
+	}
+	return message.QuickBatch(parts)
+}
+
+func BenchmarkTryCatchOverhead(b *testing.B) {
+	const childProcs = `
+  - mapping: 'root = content().uppercase()'
+  - mapping: 'root = content().uppercase()'`
+	const catchProcs = `
+  - mapping: 'root = content().uppercase()'`
+
+	for _, size := range []int{1, 10, 100} {
+		b.Run(fmt.Sprintf("bare_series/n=%d", size), func(b *testing.B) {
+			procs := benchMappingProcs(b, 2)
+			ctx := context.Background()
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				if _, err := processor.ExecuteAll(ctx, procs, benchBatch(size)); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+
+		b.Run(fmt.Sprintf("try_then_catch/n=%d", size), func(b *testing.B) {
+			idiom := []processor.V1{
+				benchProc(b, "try:"+childProcs),
+				benchProc(b, "catch:"+catchProcs),
+			}
+			ctx := context.Background()
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				if _, err := processor.ExecuteAll(ctx, idiom, benchBatch(size)); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+
+		b.Run(fmt.Sprintf("try_catch/n=%d", size), func(b *testing.B) {
+			tc := newTryCatchProc(benchMappingProcs(b, 2), benchMappingProcs(b, 1), tcDefaultErrorMeta)
+			pctx := processor.TestBatchProcContext(context.Background(), nil, nil)
+			b.ReportAllocs()
+			b.ResetTimer()
+			for i := 0; i < b.N; i++ {
+				if _, err := tc.ProcessBatch(pctx, benchBatch(size)); err != nil {
+					b.Fatal(err)
+				}
+			}
+		})
+	}
+}

--- a/internal/impl/pure/processor_try_catch_test.go
+++ b/internal/impl/pure/processor_try_catch_test.go
@@ -1,0 +1,342 @@
+// Copyright 2026 Redpanda Data, Inc.
+
+package pure_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/redpanda-data/benthos/v4/internal/component/testutil"
+	"github.com/redpanda-data/benthos/v4/internal/manager/mock"
+	"github.com/redpanda-data/benthos/v4/internal/message"
+
+	_ "github.com/redpanda-data/benthos/v4/internal/impl/pure"
+)
+
+// runTryCatchMsg runs a try_catch config against a pre-built batch (allowing the
+// caller to seed error flags or metadata) and returns all resulting batches.
+func runTryCatchMsg(t *testing.T, conf string, msg message.Batch) []message.Batch {
+	t.Helper()
+	pConf, err := testutil.ProcessorFromYAML(conf)
+	require.NoError(t, err)
+	proc, err := mock.NewManager().NewProcessor(pConf)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = proc.Close(t.Context()) })
+
+	msgs, res := proc.ProcessBatch(t.Context(), msg)
+	require.NoError(t, res)
+	return msgs
+}
+
+func runTryCatch(t *testing.T, conf string, in [][]byte) message.Batch {
+	t.Helper()
+	pConf, err := testutil.ProcessorFromYAML(conf)
+	require.NoError(t, err)
+	proc, err := mock.NewManager().NewProcessor(pConf)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = proc.Close(t.Context()) })
+
+	msgs, res := proc.ProcessBatch(t.Context(), message.QuickBatch(in))
+	require.NoError(t, res)
+	require.Len(t, msgs, 1)
+	return msgs[0]
+}
+
+func assertNoErrors(t *testing.T, b message.Batch) {
+	t.Helper()
+	_ = b.Iter(func(i int, p *message.Part) error {
+		assert.NoErrorf(t, p.ErrorGet(), "unexpected failure flag on part %v", i)
+		return nil
+	})
+}
+
+// When no processor fails the catch block is not applied and messages pass
+// through transformed and error-free.
+func TestTryCatchNoFailure(t *testing.T) {
+	out := runTryCatch(t, `
+try_catch:
+  processors:
+    - mapping: 'root = "ok: " + content().string()'
+  catch:
+    - mapping: 'root = "should not run"'
+`, [][]byte{[]byte("hello"), []byte("world")})
+
+	assert.Equal(t, [][]byte{[]byte("ok: hello"), []byte("ok: world")}, message.GetAllBytes(out))
+	assertNoErrors(t, out)
+}
+
+// A failure in the processors routes the message to the catch block, which can
+// recover it, and the error flag is cleared afterwards.
+func TestTryCatchRecovers(t *testing.T) {
+	out := runTryCatch(t, `
+try_catch:
+  processors:
+    - mapping: 'root = throw("boom")'
+  catch:
+    - mapping: 'root = "recovered"'
+`, [][]byte{[]byte("hello")})
+
+	assert.Equal(t, [][]byte{[]byte("recovered")}, message.GetAllBytes(out))
+	assertNoErrors(t, out)
+}
+
+// The catch block can inspect the failure via the error metadata field rather
+// than the error() function (the failure flag is cleared before catch runs).
+func TestTryCatchErrorAccessible(t *testing.T) {
+	out := runTryCatch(t, `
+try_catch:
+  processors:
+    - mapping: 'root = throw("specific failure")'
+  catch:
+    - mapping: 'root = "got: " + @error.what'
+`, [][]byte{[]byte("hello")})
+
+	require.Len(t, out, 1)
+	assert.Contains(t, string(out.Get(0).AsBytes()), "specific failure")
+	assertNoErrors(t, out)
+}
+
+// The caught error is a structured object: `what` holds the message and the
+// source `name` (and `label`/`path` when available) mirror the error_source_*
+// functions.
+func TestTryCatchErrorObjectFields(t *testing.T) {
+	out := runTryCatch(t, `
+try_catch:
+  processors:
+    - mapping: 'root = throw("boom")'
+  catch:
+    - mapping: 'root = {"what": @error.what, "name": @error.name}'
+`, [][]byte{[]byte("hello")})
+
+	require.Len(t, out, 1)
+	got := string(out.Get(0).AsBytes())
+	assert.Contains(t, got, `"what":"failed assignment`, "the object carries the error message under `what`")
+	assert.Contains(t, got, `"name":"mapping"`, "the object carries the failing component name")
+	assertNoErrors(t, out)
+}
+
+// The error metadata key is configurable.
+func TestTryCatchErrorMetadataKeyConfigurable(t *testing.T) {
+	out := runTryCatch(t, `
+try_catch:
+  error_metadata: why_failed
+  processors:
+    - mapping: 'root = throw("boom")'
+  catch:
+    - mapping: 'root = "reason: " + @why_failed.what'
+`, [][]byte{[]byte("hello")})
+
+	require.Len(t, out, 1)
+	assert.Contains(t, string(out.Get(0).AsBytes()), "reason: ")
+	assert.Contains(t, string(out.Get(0).AsBytes()), "boom")
+	assertNoErrors(t, out)
+}
+
+// Only the messages that failed are routed through the catch block; the others
+// pass through untouched.
+func TestTryCatchMixedBatch(t *testing.T) {
+	out := runTryCatch(t, `
+try_catch:
+  processors:
+    - mapping: |
+        if content().string() == "fail" {
+          root = throw("boom")
+        }
+  catch:
+    - mapping: 'root = "recovered"'
+`, [][]byte{[]byte("good"), []byte("fail"), []byte("good2")})
+
+	assert.Equal(t, [][]byte{
+		[]byte("good"),
+		[]byte("recovered"),
+		[]byte("good2"),
+	}, message.GetAllBytes(out))
+	assertNoErrors(t, out)
+}
+
+// "try" semantics: once a processor fails for a message the remaining
+// processors in the list are skipped for that message.
+func TestTryCatchShortCircuits(t *testing.T) {
+	out := runTryCatch(t, `
+try_catch:
+  processors:
+    - mapping: 'root = throw("first failed")'
+    - mapping: 'root = "second ran"'
+  catch: []
+`, [][]byte{[]byte("original")})
+
+	// The second processor must have been skipped, so content is unchanged, and
+	// the empty catch clears the failure flag.
+	assert.Equal(t, [][]byte{[]byte("original")}, message.GetAllBytes(out))
+	assertNoErrors(t, out)
+}
+
+// An omitted catch block swallows the error: the failure flag is cleared even
+// though no recovery processors run.
+func TestTryCatchEmptyCatchSwallows(t *testing.T) {
+	out := runTryCatch(t, `
+try_catch:
+  processors:
+    - mapping: 'root = throw("boom")'
+`, [][]byte{[]byte("original")})
+
+	assert.Equal(t, [][]byte{[]byte("original")}, message.GetAllBytes(out))
+	assertNoErrors(t, out)
+}
+
+// A catch block may filter messages away.
+func TestTryCatchCatchFilters(t *testing.T) {
+	pConf, err := testutil.ProcessorFromYAML(`
+try_catch:
+  processors:
+    - mapping: 'root = throw("boom")'
+  catch:
+    - mapping: 'root = deleted()'
+`)
+	require.NoError(t, err)
+	proc, err := mock.NewManager().NewProcessor(pConf)
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = proc.Close(t.Context()) })
+
+	msgs, res := proc.ProcessBatch(t.Context(), message.QuickBatch([][]byte{[]byte("hello")}))
+	require.NoError(t, res)
+	assert.Empty(t, msgs)
+}
+
+// When only a later processor in the list fails, the earlier successful
+// transforms are retained and the catch block still fires.
+func TestTryCatchLaterProcessorFails(t *testing.T) {
+	out := runTryCatch(t, `
+try_catch:
+  processors:
+    - mapping: 'root = "step1: " + content().string()'
+    - mapping: 'root = throw("step2 failed")'
+    - mapping: 'root = "step3 should not run"'
+  catch:
+    - mapping: 'root = "caught after: " + content().string()'
+`, [][]byte{[]byte("in")})
+
+	// catch sees the content as left by step1 (step2's throw didn't mutate it,
+	// step3 was skipped).
+	assert.Equal(t, [][]byte{[]byte("caught after: step1: in")}, message.GetAllBytes(out))
+	assertNoErrors(t, out)
+}
+
+// Metadata set before a failure is visible to the catch block.
+func TestTryCatchMetadataVisibleInCatch(t *testing.T) {
+	out := runTryCatch(t, `
+try_catch:
+  processors:
+    - mapping: 'meta foo = "bar"'
+    - mapping: 'root = throw("boom")'
+  catch:
+    - mapping: 'root = "meta was: " + meta("foo")'
+`, [][]byte{[]byte("in")})
+
+	assert.Equal(t, [][]byte{[]byte("meta was: bar")}, message.GetAllBytes(out))
+	assertNoErrors(t, out)
+}
+
+// After try_catch handles a failure the error flag is cleared, so a downstream
+// catch processor does NOT fire on it.
+func TestTryCatchClearsErrorForDownstream(t *testing.T) {
+	out := runTryCatch(t, `
+try_catch:
+  processors:
+    - mapping: 'root = throw("boom")'
+  catch:
+    - mapping: 'root = "handled"'
+`, [][]byte{[]byte("in")})
+	require.Len(t, out, 1)
+	assert.Equal(t, [][]byte{[]byte("handled")}, message.GetAllBytes(out))
+	assertNoErrors(t, out)
+}
+
+// FOUNDATION PROBE: a message that arrives already in an errored state has the
+// `processors` skipped entirely (inherited "try" semantics — ExecuteTryAll skips
+// pre-errored messages) and is routed straight to the catch block. Documents
+// that try_catch does NOT define a fresh error scope today.
+func TestTryCatchPreExistingErrorSkipsProcessors(t *testing.T) {
+	msg := message.QuickBatch([][]byte{[]byte("original")})
+	msg.Get(0).ErrorSet(errors.New("prior failure"))
+
+	out := runTryCatchMsg(t, `
+try_catch:
+  processors:
+    - mapping: 'root = "processors ran"'
+  catch:
+    - mapping: 'root = "caught: " + @error.what'
+`, msg)
+
+	require.Len(t, out, 1)
+	// The `processors` were skipped (output is not "processors ran"); the catch
+	// fired against the PRE-EXISTING error, read from metadata.
+	assert.Equal(t, "caught: prior failure", string(out[0].Get(0).AsBytes()))
+	assertNoErrors(t, out[0])
+}
+
+// If a catch processor itself fails, the new error is NOT cleared: a failed
+// recovery propagates downstream rather than being reported as a success.
+func TestTryCatchFailingCatchPropagates(t *testing.T) {
+	out := runTryCatch(t, `
+try_catch:
+  processors:
+    - mapping: 'root = throw("original")'
+  catch:
+    - mapping: 'root = throw("catch itself failed")'
+`, [][]byte{[]byte("in")})
+
+	require.Equal(t, 1, out.Len())
+	err := out.Get(0).ErrorGet()
+	require.Error(t, err, "a failure within the catch block must propagate")
+	assert.Contains(t, err.Error(), "catch itself failed")
+}
+
+// In a mixed batch, a catch failure on one message propagates while a successful
+// recovery on another is cleared — proving the propagation is per-message.
+func TestTryCatchPartialCatchFailure(t *testing.T) {
+	out := runTryCatch(t, `
+try_catch:
+  processors:
+    - mapping: 'root = throw("boom")'
+  catch:
+    - mapping: |
+        if content().string() == "explode" {
+          root = throw("catch failed")
+        } else {
+          root = "recovered"
+        }
+`, [][]byte{[]byte("ok"), []byte("explode")})
+
+	require.Equal(t, 2, out.Len())
+
+	// First message: catch recovered it, error cleared.
+	assert.Equal(t, "recovered", string(out.Get(0).AsBytes()))
+	assert.NoError(t, out.Get(0).ErrorGet())
+
+	// Second message: catch failed, error propagates.
+	require.Error(t, out.Get(1).ErrorGet())
+	assert.Contains(t, out.Get(1).ErrorGet().Error(), "catch failed")
+}
+
+// Inside the catch block the failure flag has been cleared, so the error()
+// function reports no error; the failure is available via metadata instead.
+func TestTryCatchErrorFunctionClearedInCatch(t *testing.T) {
+	out := runTryCatch(t, `
+try_catch:
+  processors:
+    - mapping: 'root = throw("boom")'
+  catch:
+    - mapping: 'root = {"errored": errored(), "from_func": error().or("none"), "from_meta": @error.what}'
+`, [][]byte{[]byte("in")})
+
+	require.Equal(t, 1, out.Len())
+	got := string(out.Get(0).AsBytes())
+	assert.Contains(t, got, `"errored":false`, "errored() is false inside catch (flag cleared)")
+	assert.Contains(t, got, `"from_func":"none"`, "error() reports no error inside catch")
+	assert.Contains(t, got, `"from_meta":"failed assignment`, "the failure is available via metadata")
+	assertNoErrors(t, out)
+}

--- a/internal/manager/mock/manager.go
+++ b/internal/manager/mock/manager.go
@@ -29,7 +29,8 @@ import (
 // Manager provides a mock benthos manager that components can use to test
 // interactions with fake resources.
 type Manager struct {
-	Version string
+	Version    string
+	StrictMode bool
 
 	Inputs          map[string]*Input
 	Caches          map[string]map[string]CacheItem
@@ -75,6 +76,11 @@ func NewManager() *Manager {
 // benthos engine.
 func (m *Manager) EngineVersion() string {
 	return m.Version
+}
+
+// Strict reports whether strict error handling is enabled.
+func (m *Manager) Strict() bool {
+	return m.StrictMode
 }
 
 // ForStream returns the same mock manager.

--- a/internal/manager/strict_test.go
+++ b/internal/manager/strict_test.go
@@ -1,0 +1,31 @@
+// Copyright 2026 Redpanda Data, Inc.
+
+package manager_test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/redpanda-data/benthos/v4/internal/manager"
+)
+
+func TestManagerStrictDefaultsOff(t *testing.T) {
+	mgr, err := manager.New(manager.NewResourceConfig())
+	require.NoError(t, err)
+	assert.False(t, mgr.Strict())
+}
+
+// The strict flag must survive every manager derivation, since components
+// (pipelines, processors, outputs) are constructed via derived managers.
+func TestManagerStrictPreservedThroughDerivation(t *testing.T) {
+	mgr, err := manager.New(manager.NewResourceConfig(), manager.OptSetStrict(true))
+	require.NoError(t, err)
+	require.True(t, mgr.Strict())
+
+	assert.True(t, mgr.ForStream("s").Strict(), "ForStream must preserve strict")
+	assert.True(t, mgr.IntoPath("a", "b").Strict(), "IntoPath must preserve strict")
+	assert.True(t, mgr.ForStream("s").IntoPath("pipeline", "processors", "0").Strict(),
+		"nested stream + path derivation must preserve strict")
+}

--- a/internal/manager/type.go
+++ b/internal/manager/type.go
@@ -77,6 +77,14 @@ type Type struct {
 	// their own custom versioning scheme.
 	engineVersion string
 
+	// When true the engine treats processing errors as terminal for the
+	// affected message: error-flagged messages skip the remaining processors in
+	// their chain and are rejected at the output rather than written. Recovery is
+	// performed by wrapping the fallible step within a try_catch or retry
+	// processor (a standalone catch does not recover here, as the failed message
+	// short-circuits past it).
+	strict bool
+
 	// Keeps track of the full configuration path of the component that holds
 	// the manager. This value is used only in observability and therefore it
 	// is acceptable that this does not fully represent reality.
@@ -141,6 +149,15 @@ func OptSetStreamHTTPNamespacing(enabled bool) OptFunc {
 func OptSetEngineVersion(v string) OptFunc {
 	return func(t *Type) {
 		t.engineVersion = v
+	}
+}
+
+// OptSetStrict enables strict error handling, where a processing error is
+// terminal for the affected message unless recovered by wrapping the fallible
+// step within a try_catch or retry processor.
+func OptSetStrict(strict bool) OptFunc {
+	return func(t *Type) {
+		t.strict = strict
 	}
 }
 
@@ -359,6 +376,11 @@ func New(conf ResourceConfig, opts ...OptFunc) (*Type, error) {
 // string could be any format.
 func (t *Type) EngineVersion() string {
 	return t.engineVersion
+}
+
+// Strict returns true when the engine is configured for strict error handling.
+func (t *Type) Strict() bool {
+	return t.strict
 }
 
 //------------------------------------------------------------------------------

--- a/internal/pipeline/constructor.go
+++ b/internal/pipeline/constructor.go
@@ -61,9 +61,9 @@ func New(conf Config, mgr bundle.NewManagement) (processor.Pipeline, error) {
 		}
 	}
 	if conf.Threads == 1 {
-		return NewProcessor(processors...), nil
+		return NewProcessor(mgr.Strict(), processors...), nil
 	}
-	return NewPool(conf.Threads, mgr.Logger(), processors...)
+	return NewPool(conf.Threads, mgr.Strict(), mgr.Logger(), processors...)
 }
 
 // FromAny returns a pipeline config from a parsed config, yaml node or map.

--- a/internal/pipeline/pool.go
+++ b/internal/pipeline/pool.go
@@ -31,8 +31,9 @@ type Pool struct {
 	shutSig *shutdown.Signaller
 }
 
-// NewPool creates a new processing pool.
-func NewPool(threads int, log log.Modular, msgProcessors ...processor.V1) (*Pool, error) {
+// NewPool creates a new processing pool. When strict is true the workers apply
+// strict error handling.
+func NewPool(threads int, strict bool, log log.Modular, msgProcessors ...processor.V1) (*Pool, error) {
 	if threads <= 0 {
 		threads = runtime.NumCPU()
 	}
@@ -46,7 +47,7 @@ func NewPool(threads int, log log.Modular, msgProcessors ...processor.V1) (*Pool
 	}
 
 	for i := range p.workers {
-		proc := NewProcessor(msgProcessors...)
+		proc := NewProcessor(strict, msgProcessors...)
 		proc.noCloseProcs = true
 		p.workers[i] = proc
 	}

--- a/internal/pipeline/pool_test.go
+++ b/internal/pipeline/pool_test.go
@@ -49,7 +49,7 @@ func TestPoolBasic(t *testing.T) {
 		mockProc.dropChan <- true
 	}()
 
-	proc, err := pipeline.NewPool(1, log.Noop(), mockProc)
+	proc, err := pipeline.NewPool(1, false, log.Noop(), mockProc)
 	require.NoError(t, err)
 
 	tChan, resChan := make(chan message.Transaction), make(chan error)
@@ -142,7 +142,7 @@ func TestPoolMultiMsgs(t *testing.T) {
 
 	mockProc := &mockSplitProcessor{}
 
-	proc, err := pipeline.NewPool(1, log.Noop(), mockProc)
+	proc, err := pipeline.NewPool(1, false, log.Noop(), mockProc)
 	require.NoError(t, err)
 
 	tChan, resChan := make(chan message.Transaction), make(chan error)
@@ -303,7 +303,7 @@ func TestPoolProcessorsNotClosedEarly(t *testing.T) {
 		},
 	}
 
-	pool, err := pipeline.NewPool(2, log.Noop(), proc)
+	pool, err := pipeline.NewPool(2, false, log.Noop(), proc)
 	require.NoError(t, err)
 
 	tChan := make(chan message.Transaction)

--- a/internal/pipeline/processor.go
+++ b/internal/pipeline/processor.go
@@ -19,6 +19,7 @@ import (
 // either propagate a new message or drop it.
 type Processor struct {
 	noCloseProcs  bool
+	strict        bool
 	msgProcessors []processor.V1
 
 	messagesOut chan message.Transaction
@@ -29,9 +30,12 @@ type Processor struct {
 	shutSig *shutdown.Signaller
 }
 
-// NewProcessor returns a new message processing pipeline.
-func NewProcessor(msgProcessors ...processor.V1) *Processor {
+// NewProcessor returns a new message processing pipeline. When strict is true
+// the pipeline applies strict error handling: a message that fails a processor
+// skips the remaining processors and is rejected at the output.
+func NewProcessor(strict bool, msgProcessors ...processor.V1) *Processor {
 	return &Processor{
+		strict:        strict,
 		msgProcessors: msgProcessors,
 		messagesOut:   make(chan message.Transaction),
 		responsesIn:   make(chan error),
@@ -45,6 +49,10 @@ func NewProcessor(msgProcessors ...processor.V1) *Processor {
 func (p *Processor) loop() {
 	closeNowCtx, cnDone := p.shutSig.HardStopCtx(context.Background())
 	defer cnDone()
+
+	if p.strict {
+		closeNowCtx = processor.WithStrict(closeNowCtx)
+	}
 
 	defer func() {
 		if !p.noCloseProcs {

--- a/internal/pipeline/processor_test.go
+++ b/internal/pipeline/processor_test.go
@@ -59,7 +59,7 @@ func TestProcessorPipeline(t *testing.T) {
 		mockProc.dropChan <- true
 	}()
 
-	proc := pipeline.NewProcessor(mockProc)
+	proc := pipeline.NewProcessor(false, mockProc)
 
 	tChan, resChan := make(chan message.Transaction), make(chan error)
 
@@ -192,7 +192,7 @@ func TestProcessorMultiMsgs(t *testing.T) {
 	defer done()
 
 	mockProc := &mockSplitProcessor{}
-	proc := pipeline.NewProcessor(mockProc)
+	proc := pipeline.NewProcessor(false, mockProc)
 
 	tChan, resChan := make(chan message.Transaction), make(chan error)
 	require.NoError(t, proc.Consume(tChan))
@@ -270,7 +270,7 @@ func TestProcessorMultiMsgsBatchError(t *testing.T) {
 	defer done()
 
 	mockProc := &mockSplitProcessor{}
-	proc := pipeline.NewProcessor(mockProc)
+	proc := pipeline.NewProcessor(false, mockProc)
 
 	tChan, resChan := make(chan message.Transaction), make(chan error)
 
@@ -387,7 +387,7 @@ func TestProcessorMultiMsgsBatchUnknownError(t *testing.T) {
 	defer done()
 
 	mockProc := &mockPhantomProcessor{}
-	proc := pipeline.NewProcessor(mockProc)
+	proc := pipeline.NewProcessor(false, mockProc)
 
 	tChan, resChan := make(chan message.Transaction), make(chan error)
 

--- a/public/service/environment.go
+++ b/public/service/environment.go
@@ -357,7 +357,7 @@ func (e *Environment) RegisterOutput(name string, spec *ConfigSpec, ctor OutputC
 				return nil, fmt.Errorf("invalid maxInFlight parameter: %v", maxInFlight)
 			}
 			w := newAirGapWriter(nm, op)
-			o, err := output.NewAsyncWriter(conf.Type, maxInFlight, w, nm)
+			o, err := output.NewAsyncWriter(conf.Type, maxInFlight, nm.Strict(), w, nm)
 			if err != nil {
 				return nil, err
 			}
@@ -403,7 +403,7 @@ func (e *Environment) RegisterBatchOutput(name string, spec *ConfigSpec, ctor Ba
 			}
 
 			w := newAirGapBatchWriter(nm, op)
-			o, err := output.NewAsyncWriter(conf.Type, maxInFlight, w, nm)
+			o, err := output.NewAsyncWriter(conf.Type, maxInFlight, nm.Strict(), w, nm)
 			if err != nil {
 				return nil, err
 			}

--- a/public/service/resources.go
+++ b/public/service/resources.go
@@ -383,7 +383,7 @@ func (r *Resources) IntoPath(pathSegments ...string) *Resources {
 // output would be executed within a standard Benthos pipeline.
 func (r *Resources) ManagedBatchOutput(typeName string, maxInFlight int, b BatchOutput) (*OwnedOutput, error) {
 	w := newAirGapBatchWriter(r.mgr, b)
-	o, err := output.NewAsyncWriter(typeName, maxInFlight, w, r.mgr)
+	o, err := output.NewAsyncWriter(typeName, maxInFlight, r.mgr.Strict(), w, r.mgr)
 	if err != nil {
 		return nil, err
 	}

--- a/public/service/stream_builder.go
+++ b/public/service/stream_builder.go
@@ -47,6 +47,7 @@ import (
 // endpoints.
 type StreamBuilder struct {
 	engineVersion string
+	strict        bool
 
 	http       api.Config
 	threads    int
@@ -112,6 +113,14 @@ func (s *StreamBuilder) getLintContext() docs.LintContext {
 }
 
 //------------------------------------------------------------------------------
+
+// SetStrict configures the stream for strict error handling, where a processing
+// error is terminal for the affected message unless recovered by wrapping the
+// fallible step within a try_catch or retry processor. This setting is also
+// derived from a config's `error_handling.strict` field when one is provided.
+func (s *StreamBuilder) SetStrict(strict bool) {
+	s.strict = strict
+}
 
 // SetEngineVersion sets the version string representing the Benthos engine that
 // components will see. By default a best attempt will be made to determine a
@@ -638,6 +647,7 @@ func (s *StreamBuilder) setFromConfig(sconf config.Type) {
 	s.logger = sconf.Logger
 	s.metrics = sconf.Metrics
 	s.tracer = sconf.Tracer
+	s.strict = sconf.ErrorHandling.Strict
 }
 
 // SetBufferYAML parses a buffer YAML configuration and sets it to the builder
@@ -912,6 +922,7 @@ func (s *StreamBuilder) buildWithEnv(env *bundle.Environment) (*Stream, error) {
 		conf.ResourceConfig,
 		manager.OptSetAPIReg(apiMut),
 		manager.OptSetEngineVersion(s.engineVersion),
+		manager.OptSetStrict(s.strict),
 		manager.OptSetLogger(logger),
 		manager.OptSetMetrics(stats),
 		manager.OptSetTracer(tracer),

--- a/public/service/strict_fallback_test.go
+++ b/public/service/strict_fallback_test.go
@@ -1,0 +1,212 @@
+// Copyright 2026 Redpanda Data, Inc.
+
+package service_test
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/redpanda-data/benthos/v4/public/service"
+
+	_ "github.com/redpanda-data/benthos/v4/public/components/io"
+	_ "github.com/redpanda-data/benthos/v4/public/components/pure"
+)
+
+// pushOneAndStop runs the built stream, pushes a single message, then stops the
+// stream, returning the acknowledgement error (non-nil = the message was
+// nacked). Bounded by timeouts so a poison/backpressure loop cannot hang it.
+func pushOneAndStop(t *testing.T, b *service.StreamBuilder, payload string) error {
+	t.Helper()
+	pushFn, err := b.AddBatchProducerFunc()
+	require.NoError(t, err)
+	strm, err := b.Build()
+	require.NoError(t, err)
+
+	var pushErr error
+	wg := sync.WaitGroup{}
+	wg.Go(func() {
+		ctx, done := context.WithTimeout(context.Background(), 5*time.Second)
+		defer done()
+		pushErr = pushFn(ctx, service.MessageBatch{service.NewMessage([]byte(payload))})
+		time.Sleep(200 * time.Millisecond)
+		_ = strm.StopWithin(5 * time.Second)
+	})
+	require.NoError(t, strm.Run(context.Background()))
+	wg.Wait()
+	return pushErr
+}
+
+func readOrEmpty(path string) string {
+	b, err := os.ReadFile(path)
+	if err != nil {
+		return ""
+	}
+	return string(b)
+}
+
+// THE HEADLINE CON-461 PATTERN: under strict, when a primary output's own
+// processors fail (e.g. parquet_encode), the failed tier rejects and `fallback`
+// forwards the ORIGINAL (pre-processor) message to the secondary tier, which
+// writes it. The corrupt/unprocessed data is never written to the primary.
+func TestStrictFallbackRecoversFailedOutputProcessor(t *testing.T) {
+	dir := t.TempDir()
+	a, bf := filepath.Join(dir, "A.txt"), filepath.Join(dir, "B.txt")
+
+	sb := service.NewStreamBuilder()
+	require.NoError(t, sb.SetLoggerYAML("level: NONE"))
+	sb.SetStrict(true)
+	require.NoError(t, sb.AddOutputYAML(fmt.Sprintf(`
+fallback:
+  - file:
+      codec: lines
+      path: %s
+    processors:
+      - mapping: 'root = throw("encode failed")'
+  - file:
+      codec: lines
+      path: %s
+`, a, bf)))
+
+	ackErr := pushOneAndStop(t, sb, "raw-payload")
+
+	assert.NoError(t, ackErr, "the message is recovered by the secondary tier, so the overall delivery is acked")
+	assert.Empty(t, readOrEmpty(a), "the primary must NOT write the message whose processing failed")
+	assert.Equal(t, "raw-payload\n", readOrEmpty(bf), "the secondary tier receives and writes the original, pre-processor message")
+}
+
+// Sanity: when the primary output's processors SUCCEED under strict, the primary
+// writes (transformed) and the fallback secondary is never used.
+func TestStrictFallbackPrimarySuccess(t *testing.T) {
+	dir := t.TempDir()
+	a, bf := filepath.Join(dir, "A.txt"), filepath.Join(dir, "B.txt")
+
+	sb := service.NewStreamBuilder()
+	require.NoError(t, sb.SetLoggerYAML("level: NONE"))
+	sb.SetStrict(true)
+	require.NoError(t, sb.AddOutputYAML(fmt.Sprintf(`
+fallback:
+  - file:
+      codec: lines
+      path: %s
+    processors:
+      - mapping: 'root = content().uppercase()'
+  - file:
+      codec: lines
+      path: %s
+`, a, bf)))
+
+	ackErr := pushOneAndStop(t, sb, "ok")
+
+	assert.NoError(t, ackErr)
+	assert.Equal(t, "OK\n", readOrEmpty(a), "the primary writes the successfully processed message")
+	assert.Empty(t, readOrEmpty(bf), "the secondary tier is not used when the primary succeeds")
+}
+
+// When BOTH fallback tiers fail their own processing under strict, nothing is
+// written anywhere and the message is nacked (backpressure).
+func TestStrictFallbackBothTiersFailProcessors(t *testing.T) {
+	dir := t.TempDir()
+	a, bf := filepath.Join(dir, "A.txt"), filepath.Join(dir, "B.txt")
+
+	sb := service.NewStreamBuilder()
+	require.NoError(t, sb.SetLoggerYAML("level: NONE"))
+	sb.SetStrict(true)
+	require.NoError(t, sb.AddOutputYAML(fmt.Sprintf(`
+fallback:
+  - file:
+      codec: lines
+      path: %s
+    processors:
+      - mapping: 'root = throw("A failed")'
+  - file:
+      codec: lines
+      path: %s
+    processors:
+      - mapping: 'root = throw("B failed")'
+`, a, bf)))
+
+	ackErr := pushOneAndStop(t, sb, "hello")
+
+	assert.Error(t, ackErr, "with every tier failing, the message must be nacked")
+	assert.Empty(t, readOrEmpty(a), "primary writes nothing")
+	assert.Empty(t, readOrEmpty(bf), "secondary writes nothing")
+}
+
+// A message already flagged BEFORE reaching the output (a pipeline error) is
+// rejected by EVERY fallback tier — it arrives flagged at each — so nothing is
+// written and it is nacked. (Contrast with the output-processor case above.)
+func TestStrictFallbackFlaggedOnEntryRejectedByAllTiers(t *testing.T) {
+	dir := t.TempDir()
+	a, bf := filepath.Join(dir, "A.txt"), filepath.Join(dir, "B.txt")
+
+	sb := service.NewStreamBuilder()
+	require.NoError(t, sb.SetLoggerYAML("level: NONE"))
+	sb.SetStrict(true)
+	require.NoError(t, sb.AddProcessorYAML(`mapping: 'root = throw("pipeline failed")'`))
+	require.NoError(t, sb.AddOutputYAML(fmt.Sprintf(`
+fallback:
+  - file: {codec: lines, path: %s}
+  - file: {codec: lines, path: %s}
+`, a, bf)))
+
+	ackErr := pushOneAndStop(t, sb, "hello")
+
+	assert.Error(t, ackErr, "a message flagged on entry is rejected by every tier and nacked")
+	assert.Empty(t, readOrEmpty(a), "primary writes nothing")
+	assert.Empty(t, readOrEmpty(bf), "secondary writes nothing")
+}
+
+// An unguarded pipeline error under strict, with a single output: the message is
+// nacked and never written to the output.
+func TestStrictUnguardedPipelineErrorNackedNotWritten(t *testing.T) {
+	dir := t.TempDir()
+	out := filepath.Join(dir, "out.txt")
+
+	sb := service.NewStreamBuilder()
+	require.NoError(t, sb.SetLoggerYAML("level: NONE"))
+	sb.SetStrict(true)
+	require.NoError(t, sb.AddProcessorYAML(`mapping: 'root = throw("boom")'`))
+	require.NoError(t, sb.AddOutputYAML(fmt.Sprintf(`file: {codec: lines, path: %s}`, out)))
+
+	ackErr := pushOneAndStop(t, sb, "hello")
+
+	assert.Error(t, ackErr, "the errored message must be nacked")
+	assert.Empty(t, readOrEmpty(out), "the errored message must not be written to the output")
+}
+
+// CONTRAST (documents why strict matters): WITHOUT strict, the same
+// failed-output-processor fallback writes the raw, unprocessed data to the
+// primary (the CON-461 footgun) and never reaches the secondary.
+func TestNonStrictFallbackWritesRawToPrimary(t *testing.T) {
+	dir := t.TempDir()
+	a, bf := filepath.Join(dir, "A.txt"), filepath.Join(dir, "B.txt")
+
+	sb := service.NewStreamBuilder()
+	require.NoError(t, sb.SetLoggerYAML("level: NONE"))
+	// strict NOT set (default false).
+	require.NoError(t, sb.AddOutputYAML(fmt.Sprintf(`
+fallback:
+  - file:
+      codec: lines
+      path: %s
+    processors:
+      - mapping: 'root = throw("encode failed")'
+  - file:
+      codec: lines
+      path: %s
+`, a, bf)))
+
+	ackErr := pushOneAndStop(t, sb, "raw-payload")
+
+	assert.NoError(t, ackErr)
+	assert.Equal(t, "raw-payload\n", readOrEmpty(a), "without strict the unprocessed data is written to the primary (the footgun)")
+	assert.Empty(t, readOrEmpty(bf), "the secondary is never reached because the primary 'succeeds'")
+}


### PR DESCRIPTION
## Summary

This delivers a coherent fix for a long-standing class of error-handling footgun, in two parts:

1. **Fixes the data-corruption bug** where a failure in an output's processors (for example `parquet_encode` in an `aws_s3` output's `batching.processors`) caused the original, unprocessed data to be written anyway — e.g. raw JSON written to object storage with a `.parquet` extension.
2. **Introduces opt-in strict error handling** — a new `error_handling.strict` config field (default `false`) that makes a processing error terminal for the affected message. This is the foundation for making strict behaviour the default in the next major version.

The default behaviour is unchanged unless `error_handling.strict` is enabled.

## What's included

- **`try_catch` processor** — fuses `try` + `catch` into a single block with an explicit recovery path. When a step fails, the error is moved into a metadata object (`error` by default, configurable via `error_metadata`) with `what`/`name`/`label`/`path` fields and the failure flag is cleared, so the `catch` block runs under normal error semantics and reads the failure as a variable (e.g. `@error.what`).
- **`error_handling.strict` config field** — when enabled, an errored message skips the remaining processors in its chain and is rejected (nacked) at the output rather than written. Recovery of expected errors is performed with `try_catch` (or `retry` for transient failures); an unrecovered error is redelivered, applying back-pressure until it is addressed.
- **Strict-aware engine** — `ExecuteAll` short-circuits errored messages when strict (propagating through nested composition processors); the `AsyncWriter` rejects flagged messages per-message via `batch.Error`, emitting a reject counter and an actionable warning. Outputs with explicit discard/nack semantics (`drop`, `reject`, `sync_response`) opt out.
- **Lint warning** — under strict, any `catch` processor is flagged (it can no longer observe a failed message), pointing authors to `try_catch`.

## Behaviour notes

- A failure in a primary output's own processors composes cleanly with `fallback`: the failed tier rejects and the original (pre-processor) message is forwarded to the next tier, which writes it — the recommended "encode here, fall back to raw there" pattern.
- A message flagged earlier in the pipeline arrives flagged at every output (including `fallback` tiers), so it is rejected everywhere and nacked; to route such a message to a dead-letter destination, clear the flag first.

## Tests

Unit and end-to-end coverage for: the `try_catch` recovery and error-object semantics; strict short-circuiting across pipeline and nested composition processors; the `AsyncWriter` reject path (including mixed batches); manager-flag propagation; the lint rule; and the strict + `fallback` + output-processor composition above. Success-path benchmarks confirm no hot-path regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
