### PR TITLE
http: extract response headers into metadata on error responses

### DIFF
--- a/internal/httpclient/client.go
+++ b/internal/httpclient/client.go
@@ -214,28 +214,39 @@ func (h *Client) waitForAccess(ctx context.Context) bool {
 	}
 }
 
+// ExtractHeaderMeta sets response header values as metadata on the provided
+// message according to the configured metadata extraction filter. It is a no-op
+// when no extraction filter is configured or when header is nil, and is shared
+// by both the successful response path and the error response path so that
+// configured headers (e.g. Retry-After on a 429) are extracted regardless of
+// the response status code.
+func (h *Client) ExtractHeaderMeta(p *service.Message, header http.Header) {
+	if h.metaExtractFilter.IsEmpty() {
+		return
+	}
+	for k, values := range header {
+		normalisedHeader := strings.ToLower(k)
+		if len(values) > 0 && h.metaExtractFilter.Match(normalisedHeader) {
+			if len(values) == 1 {
+				p.MetaSetMut(normalisedHeader, values[0])
+			} else {
+				metaVal := make([]any, 0, len(values))
+				for _, v := range values {
+					metaVal = append(metaVal, v)
+				}
+				p.MetaSetMut(normalisedHeader, metaVal)
+			}
+		}
+	}
+}
+
 // ResponseToBatch attempts to parse an HTTP response into a 2D slice of bytes.
 func (h *Client) ResponseToBatch(res *http.Response) (service.MessageBatch, error) {
 	var resMsg service.MessageBatch
 
 	annotatePart := func(p *service.Message) {
 		p.MetaSetMut("http_status_code", res.StatusCode)
-		if !h.metaExtractFilter.IsEmpty() {
-			for k, values := range res.Header {
-				normalisedHeader := strings.ToLower(k)
-				if len(values) > 0 && h.metaExtractFilter.Match(normalisedHeader) {
-					if len(values) == 1 {
-						p.MetaSetMut(normalisedHeader, values[0])
-					} else {
-						metaVal := make([]any, 0, len(values))
-						for _, v := range values {
-							metaVal = append(metaVal, v)
-						}
-						p.MetaSetMut(normalisedHeader, metaVal)
-					}
-				}
-			}
-		}
+		h.ExtractHeaderMeta(p, res.Header)
 	}
 
 	if res.Body == nil {
@@ -498,7 +509,7 @@ func unexpectedErr(res *http.Response) error {
 	if err != nil {
 		return err
 	}
-	return ErrUnexpectedHTTPRes{Code: res.StatusCode, S: res.Status, Body: body}
+	return ErrUnexpectedHTTPRes{Code: res.StatusCode, S: res.Status, Body: body, Header: res.Header}
 }
 
 // Send creates an HTTP request from the client config, a provided message to be

--- a/internal/httpclient/errors.go
+++ b/internal/httpclient/errors.go
@@ -4,15 +4,17 @@ package httpclient
 
 import (
 	"fmt"
+	"net/http"
 	"strings"
 )
 
 // ErrUnexpectedHTTPRes is an error returned when an HTTP request returned an
 // unexpected response.
 type ErrUnexpectedHTTPRes struct {
-	Code int
-	S    string
-	Body []byte
+	Code   int
+	S      string
+	Body   []byte
+	Header http.Header
 }
 
 // Error returns the Error string.

--- a/internal/impl/io/processor_http.go
+++ b/internal/impl/io/processor_http.go
@@ -127,6 +127,7 @@ func (h *httpProc) ProcessBatch(ctx context.Context, msg service.MessageBatch) (
 				if code > 0 {
 					p.MetaSetMut("http_status_code", code)
 				}
+				h.client.ExtractHeaderMeta(p, hErr.Header)
 				p.SetError(err)
 			}
 		} else {
@@ -161,6 +162,7 @@ func (h *httpProc) ProcessBatch(ctx context.Context, msg service.MessageBatch) (
 				if ok := errors.As(err, &hErr); ok {
 					errPart.MetaSetMut("http_status_code", hErr.Code)
 				}
+				h.client.ExtractHeaderMeta(errPart, hErr.Header)
 				errPart.SetError(err)
 				responseMsg = append(responseMsg, errPart)
 			}
@@ -207,6 +209,7 @@ func (h *httpProc) ProcessBatch(ctx context.Context, msg service.MessageBatch) (
 						if ok := errors.As(err, &hErr); ok {
 							results[index].MetaSetMut("http_status_code", hErr.Code)
 						}
+						h.client.ExtractHeaderMeta(results[index], hErr.Header)
 						results[index].SetError(err)
 					}
 					resChan <- err

--- a/internal/impl/io/processor_http_test.go
+++ b/internal/impl/io/processor_http_test.go
@@ -285,6 +285,40 @@ http:
 	}
 }
 
+func TestHTTPClientExtractHeadersOnErrorResponse(t *testing.T) {
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Retry-After", "30")
+		w.WriteHeader(http.StatusTooManyRequests)
+	}))
+	defer ts.Close()
+
+	conf := parseYAMLProcConf(t, `
+http:
+  url: %v/testpost
+  retries: 0
+  extract_headers:
+    include_prefixes: [ "retry-after" ]
+`, ts.URL)
+
+	h, err := mock.NewManager().NewProcessor(conf)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	msgs, res := h.ProcessBatch(t.Context(), message.QuickBatch([][]byte{[]byte("foo")}))
+	if res != nil {
+		t.Error(res)
+	} else if expC, actC := 1, msgs[0].Len(); actC != expC {
+		t.Errorf("Wrong result count: %v != %v", actC, expC)
+	} else if exp, act := "429", msgs[0].Get(0).MetaGetStr("http_status_code"); exp != act {
+		t.Errorf("Wrong response code metadata: %v != %v", act, exp)
+	} else if exp, act := "30", msgs[0].Get(0).MetaGetStr("retry-after"); exp != act {
+		t.Errorf("Retry-After header was not extracted onto the errored message: %v != %v", act, exp)
+	} else {
+		assert.Error(t, msgs[0].Get(0).ErrorGet())
+	}
+}
+
 func TestHTTPClientSerial(t *testing.T) {
 	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		bodyBytes, err := io.ReadAll(r.Body)


### PR DESCRIPTION
## What

The `http` processor did not extract configured response headers into message metadata when the server returned a non-2xx response. For example, on a `429 Too Many Requests` the `Retry-After` header (configured via `extract_headers.include_prefixes`) never reached `metadata("retry-after")`, even though it was present in the raw response.

## Why

Header extraction was performed only in `ResponseToBatch`, which runs exclusively on a successful request. On a non-success response the client returns an `ErrUnexpectedHTTPRes` (carrying only the status code and body) and the processor copies the input message through with just `http_status_code` set — so the headers were lost.

## How

- Capture the response headers on `ErrUnexpectedHTTPRes`.
- Factor the header-extraction loop out of `ResponseToBatch` into a shared `Client.ExtractHeaderMeta` method.
- Invoke it from each of the `http` processor's error paths, so configured headers are extracted regardless of the response status code.

Adds an end-to-end test: a 429 response with `Retry-After` now populates both `http_status_code` and `retry-after` on the errored message.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
