### PR TITLE
fix(csv): promote "Output CSV column order" out of the Metadata section

### DIFF
--- a/internal/impl/io/input_csv.go
+++ b/internal/impl/io/input_csv.go
@@ -70,7 +70,7 @@ You can access these metadata fields using xref:configuration:interpolation.adoc
 
 Note: The `+"`header`"+` field is only set when `+"`parse_header_row`"+` is `+"`true`"+`.
 
-=== Output CSV column order
+== Output CSV column order
 
 When xref:guides:bloblang/advanced.adoc#creating-csv[creating CSV] from Redpanda Connect messages, the columns must be sorted lexicographically to make the output deterministic. Alternatively, when using the `+"`csv`"+` input, one can leverage the `+"`header`"+` metadata field to retrieve the column order:
 


### PR DESCRIPTION
## Problem

The `csv` input's `Description()` nests **`=== Output CSV column order`** — a how-to for producing deterministic CSV *output* (prose + a Bloblang `escape_csv` example) — as a **level-3 subsection under `== Metadata`**. It isn't metadata.

Downstream tooling in the Redpanda Connect docs extracts the `== Metadata` section verbatim into a regenerated metadata reference partial, and because a level-3 heading doesn't terminate the section, the entire "Output CSV column order" subsection (including the YAML block) is swept into the generated metadata docs. See the analysis in redpanda-data/rp-connect-docs#459.

## Fix

Promote the heading from `=== Output CSV column order` to a sibling **`== Output CSV column order`** section. It's still on the csv input page, just no longer nested inside — and no longer part of the Metadata block.

## Note

Two connectors were found doing this; the other (`gcp_cloud_storage`, `=== Credentials`) lives in redpanda-data/connect and is fixed there separately. A legitimate use of `===` under Metadata (grouping fields by operation, e.g. the `nats_kv` processor) is intentionally left as-is.