### PR TITLE
docs: add short description field for form UI help text

### DIFF
--- a/internal/docs/field.go
+++ b/internal/docs/field.go
@@ -88,6 +88,12 @@ type FieldSpec struct {
 	// Description of the field purpose (in Asciidoc).
 	Description string `json:"description,omitempty"`
 
+	// ShortDescription is a plain text summary of the field purpose, suitable
+	// for rendering as inline help within a form UI. Unlike Description it
+	// contains no markup and spans at most a sentence or two. When empty
+	// consumers are expected to fall back to Description.
+	ShortDescription string `json:"short_description,omitempty"`
+
 	// IsAdvanced is true for optional fields that will not be present in most
 	// configs.
 	IsAdvanced bool `json:"is_advanced,omitempty"`

--- a/public/service/config.go
+++ b/public/service/config.go
@@ -212,6 +212,15 @@ func (c *ConfigField) Description(d string) *ConfigField {
 	return c
 }
 
+// ShortDescription adds a plain text summary of the field to be shown as inline
+// help within a form UI, where the full Description would be too verbose. It
+// should contain no markup and span at most a sentence or two. When unset,
+// consumers fall back to the value provided by Description.
+func (c *ConfigField) ShortDescription(d string) *ConfigField {
+	c.field.ShortDescription = d
+	return c
+}
+
 // Advanced marks a config field as being advanced, and therefore it will not
 // appear in simplified documentation examples.
 func (c *ConfigField) Advanced() *ConfigField {

--- a/public/service/config_test.go
+++ b/public/service/config_test.go
@@ -3,6 +3,7 @@
 package service
 
 import (
+	"encoding/json"
 	"errors"
 	"strings"
 	"testing"
@@ -604,4 +605,32 @@ a: {}
 			}
 		})
 	}
+}
+
+func TestConfigFieldShortDescription(t *testing.T) {
+	spec := NewConfigSpec().
+		Fields(
+			NewStringField("a").
+				Description("A verbose description containing `markup` and a caveat that would be unsuitable for a form UI.").
+				ShortDescription("Plain text summary of a."),
+			NewStringField("b").
+				Description("Only a description."),
+		)
+
+	fields := spec.component.Config.Children
+	require.Len(t, fields, 2)
+
+	assert.Equal(t, "Plain text summary of a.", fields[0].ShortDescription)
+	assert.Empty(t, fields[1].ShortDescription, "must not be inferred from Description")
+
+	// Setting a short description must leave the documentation description
+	// untouched, as the two serve different consumers.
+	assert.Equal(t, "A verbose description containing `markup` and a caveat that would be unsuitable for a form UI.", fields[0].Description)
+
+	// Consumers read the field from the marshalled schema, and are expected to
+	// fall back to description when it is absent.
+	encoded, err := json.Marshal(fields)
+	require.NoError(t, err)
+	assert.Contains(t, string(encoded), `"short_description":"Plain text summary of a."`)
+	assert.Equal(t, 1, strings.Count(string(encoded), "short_description"))
 }


### PR DESCRIPTION
Field descriptions are authored for the documentation site: they contain Asciidoc markup and often run to several paragraphs. Rendering them as inline help in a form UI is unreadable.

Add a ShortDescription to FieldSpec, serialised as short_description, so components can provide a plain text one-line summary alongside the full description. Consumers fall back to Description when it is empty, making this additive for every existing schema consumer.