### PR TITLE
feat(http): make CORS request headers configurable

### DIFF
--- a/internal/httpserver/cors.go
+++ b/internal/httpserver/cors.go
@@ -5,6 +5,7 @@ package httpserver
 import (
 	"errors"
 	"net/http"
+	"strings"
 
 	"github.com/gorilla/handlers"
 
@@ -15,12 +16,14 @@ const (
 	fieldCORS               = "cors"
 	fieldCORSEnabled        = "enabled"
 	fieldCORSAllowedOrigins = "allowed_origins"
+	fieldCORSAllowedHeaders = "allowed_headers"
 )
 
 // CORSConfig contains struct configuration for allowing CORS headers.
 type CORSConfig struct {
 	Enabled        bool     `json:"enabled" yaml:"enabled"`
 	AllowedOrigins []string `json:"allowed_origins" yaml:"allowed_origins"`
+	AllowedHeaders []string `json:"allowed_headers" yaml:"allowed_headers"`
 }
 
 // NewServerCORSConfig returns a new server CORS config with default fields.
@@ -28,6 +31,7 @@ func NewServerCORSConfig() CORSConfig {
 	return CORSConfig{
 		Enabled:        false,
 		AllowedOrigins: []string{},
+		AllowedHeaders: []string{},
 	}
 }
 
@@ -40,10 +44,38 @@ func (conf CORSConfig) WrapHandler(handler http.Handler) (http.Handler, error) {
 	if len(conf.AllowedOrigins) == 0 {
 		return nil, errors.New("must specify at least one allowed origin")
 	}
-	return handlers.CORS(
+	corsHandler := handlers.CORS(
 		handlers.AllowedOrigins(conf.AllowedOrigins),
 		handlers.AllowedMethods([]string{"GET", "HEAD", "POST", "PUT", "PATCH", "DELETE"}),
-	)(handler), nil
+		handlers.AllowedHeaders(conf.AllowedHeaders),
+	)(handler)
+
+	if !conf.allowsAllHeaders() {
+		return corsHandler, nil
+	}
+
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		requestedHeaders := r.Header.Get("Access-Control-Request-Headers")
+		if r.Method != http.MethodOptions || requestedHeaders == "" {
+			corsHandler.ServeHTTP(w, r)
+			return
+		}
+
+		request := r.Clone(r.Context())
+		request.Header = r.Header.Clone()
+		request.Header.Del("Access-Control-Request-Headers")
+		w.Header().Set("Access-Control-Allow-Headers", requestedHeaders)
+		corsHandler.ServeHTTP(w, request)
+	}), nil
+}
+
+func (conf CORSConfig) allowsAllHeaders() bool {
+	for _, header := range conf.AllowedHeaders {
+		if strings.TrimSpace(header) == "*" {
+			return true
+		}
+	}
+	return false
 }
 
 // ServerCORSFieldSpec returns a field spec for an http server CORS component.
@@ -51,6 +83,7 @@ func ServerCORSFieldSpec() docs.FieldSpec {
 	return docs.FieldObject(fieldCORS, "Adds Cross-Origin Resource Sharing headers.").WithChildren(
 		docs.FieldBool(fieldCORSEnabled, "Whether to allow CORS requests.").HasDefault(false),
 		docs.FieldString(fieldCORSAllowedOrigins, "An explicit list of origins that are allowed for CORS requests.").Array().HasDefault([]any{}),
+		docs.FieldString(fieldCORSAllowedHeaders, "An explicit list of headers allowed in CORS requests. Specify `*` to allow any requested header.").Array().HasDefault([]any{}),
 	).AtVersion("3.63.0").Advanced()
 }
 
@@ -61,6 +94,9 @@ func CORSConfigFromParsed(pConf *docs.ParsedConfig) (conf CORSConfig, err error)
 		return
 	}
 	if conf.AllowedOrigins, err = pConf.FieldStringList(fieldCORSAllowedOrigins); err != nil {
+		return
+	}
+	if conf.AllowedHeaders, err = pConf.FieldStringList(fieldCORSAllowedHeaders); err != nil {
 		return
 	}
 	return

--- a/internal/httpserver/cors_test.go
+++ b/internal/httpserver/cors_test.go
@@ -79,6 +79,48 @@ func TestAPIEnableCORSOrigins(t *testing.T) {
 	assert.Empty(t, response.Header().Get("Access-Control-Allow-Origin"))
 }
 
+func TestAPIEnableCORSAllowedHeaders(t *testing.T) {
+	conf := NewServerCORSConfig()
+	conf.Enabled = true
+	conf.AllowedOrigins = []string{"*"}
+	conf.AllowedHeaders = []string{"Content-Type"}
+
+	handler, err := conf.WrapHandler(http.NewServeMux())
+	require.NoError(t, err)
+
+	request, _ := http.NewRequest("OPTIONS", "/version", http.NoBody)
+	request.Header.Set("Origin", "meow")
+	request.Header.Set("Access-Control-Request-Method", "POST")
+	request.Header.Set("Access-Control-Request-Headers", "content-type")
+
+	response := httptest.NewRecorder()
+	handler.ServeHTTP(response, request)
+
+	assert.Equal(t, http.StatusOK, response.Code)
+	assert.Equal(t, "Content-Type", response.Header().Get("Access-Control-Allow-Headers"))
+}
+
+func TestAPIEnableCORSAllHeaders(t *testing.T) {
+	conf := NewServerCORSConfig()
+	conf.Enabled = true
+	conf.AllowedOrigins = []string{"*"}
+	conf.AllowedHeaders = []string{"*"}
+
+	handler, err := conf.WrapHandler(http.NewServeMux())
+	require.NoError(t, err)
+
+	request, _ := http.NewRequest("OPTIONS", "/version", http.NoBody)
+	request.Header.Set("Origin", "meow")
+	request.Header.Set("Access-Control-Request-Method", "POST")
+	request.Header.Set("Access-Control-Request-Headers", "content-type, x-request-id")
+
+	response := httptest.NewRecorder()
+	handler.ServeHTTP(response, request)
+
+	assert.Equal(t, http.StatusOK, response.Code)
+	assert.Equal(t, "content-type, x-request-id", response.Header().Get("Access-Control-Allow-Headers"))
+}
+
 func TestAPIEnableCORSNoHeaders(t *testing.T) {
 	conf := NewServerCORSConfig()
 	conf.Enabled = true

--- a/internal/impl/io/input_http_server.go
+++ b/internal/impl/io/input_http_server.go
@@ -58,6 +58,7 @@ const (
 	hsiFieldCORS                    = "cors"
 	hsiFieldCORSEnabled             = "enabled"
 	hsiFieldCORSAllowedOrigins      = "allowed_origins"
+	hsiFieldCORSAllowedHeaders      = "allowed_headers"
 	hsiFieldResponse                = "sync_response"
 	hsiFieldResponseStatus          = "status"
 	hsiFieldResponseHeaders         = "headers"
@@ -145,6 +146,9 @@ func corsConfigFromParsed(pConf *service.ParsedConfig) (conf httpserver.CORSConf
 		return
 	}
 	if conf.AllowedOrigins, err = pConf.FieldStringList(hsiFieldCORSAllowedOrigins); err != nil {
+		return
+	}
+	if conf.AllowedHeaders, err = pConf.FieldStringList(hsiFieldCORSAllowedHeaders); err != nil {
 		return
 	}
 	return

--- a/internal/impl/io/input_http_server_test.go
+++ b/internal/impl/io/input_http_server_test.go
@@ -1324,6 +1324,7 @@ http_server:
   cors:
     enabled: true
     allowed_origins: [ foo, bar ]
+    allowed_headers: [ Content-Type ]
 `, freePort)
 
 	server, err := mock.NewManager().NewInput(conf)
@@ -1343,7 +1344,7 @@ http_server:
 
 		req.Header.Add("Origin", "foo")
 		req.Header.Add("Access-Control-Request-Method", "POST")
-		req.Header.Set("Content-Type", "text/plain")
+		req.Header.Set("Access-Control-Request-Headers", "content-type")
 
 		if resp, cerr = http.DefaultClient.Do(req); cerr == nil {
 			succeeded = true
@@ -1354,6 +1355,7 @@ http_server:
 
 	assert.Equal(t, "200 OK", resp.Status)
 	assert.Equal(t, "foo", resp.Header.Get("Access-Control-Allow-Origin"))
+	assert.Equal(t, "Content-Type", resp.Header.Get("Access-Control-Allow-Headers"))
 }
 
 // TestHTTPServerReload tests that the server can be closed and recreated on the same port

--- a/internal/impl/io/input_http_server_wasm.go
+++ b/internal/impl/io/input_http_server_wasm.go
@@ -57,6 +57,7 @@ const (
 	hsiFieldCORS                    = "cors"
 	hsiFieldCORSEnabled             = "enabled"
 	hsiFieldCORSAllowedOrigins      = "allowed_origins"
+	hsiFieldCORSAllowedHeaders      = "allowed_headers"
 	hsiFieldResponse                = "sync_response"
 	hsiFieldResponseStatus          = "status"
 	hsiFieldResponseHeaders         = "headers"
@@ -140,6 +141,9 @@ func corsConfigFromParsed(pConf *service.ParsedConfig) (conf httpserver.CORSConf
 		return
 	}
 	if conf.AllowedOrigins, err = pConf.FieldStringList(hsiFieldCORSAllowedOrigins); err != nil {
+		return
+	}
+	if conf.AllowedHeaders, err = pConf.FieldStringList(hsiFieldCORSAllowedHeaders); err != nil {
 		return
 	}
 	return


### PR DESCRIPTION
## Problem

Browser JSON requests send `Content-Type` in `Access-Control-Request-Headers`. Benthos rejected this header during preflight, returning `403`.

## Fix

Adds configurable CORS request headers through `cors.allowed_headers`.

- Supports explicit allowed headers.
- Supports `*` for all requested headers.
- Applies to native and WASM implementations.
- Prevents deployments from requiring proxy-specific CORS workarounds.

## Testing

`go test ./internal/httpserver ./internal/impl/io`
