### PR TITLE
chore: bump to Go 1.26.6

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/redpanda-data/benthos/v4
 
-go 1.26.4
+go 1.26.6
 
 require (
 	cuelang.org/go v0.17.1


### PR DESCRIPTION
Bump to Go 1.26.6 address security vulnerabilities.

> go1.26.6 (released 2026-08-13) includes security fixes to the go command, and the crypto/tls, encoding/asn1, encoding/xml, html/template, net, net/http, and net/url packages, as well as bug fixes to the compiler, the linker, the runtime, and the crypto/tls and os packages. See the [Go 1.26.6 milestone](https://github.com/golang/go/issues?q=milestone%3AGo1.26.6+label%3ACherryPickApproved) on our issue tracker for details.