### PR TITLE
input/websocket: add a max_message_size read limit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ Changelog
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+### Added
+
+- Input `websocket`: Added a `max_message_size` field that bounds the size of individual inbound messages via the underlying connection's read limit. (@prakhargarg105)
+
 ## 4.77.0 - 2026-07-30
 
 ### Added

--- a/internal/impl/io/input_websocket.go
+++ b/internal/impl/io/input_websocket.go
@@ -5,6 +5,7 @@ package io
 import (
 	"context"
 	"crypto/tls"
+	"errors"
 	"fmt"
 	"io/fs"
 	"net/http"
@@ -53,6 +54,9 @@ func websocketInputSpec() *service.ConfigSpec {
 				string(wsOpenMsgTypeText):   "Text data open_message. The text message payload is interpreted as UTF-8 encoded text data.",
 			}).Description("An optional flag to indicate the data type of open_message.").
 				Advanced().Default(string(wsOpenMsgTypeBinary)),
+			service.NewIntField("max_message_size").
+				Description("An optional maximum size in bytes for individual messages received from the server. When a message exceeding this limit is received the connection is closed with a 1009 (message too big) status and the input reconnects. A value of 0 disables the limit.").
+				Advanced().Default(0),
 			service.NewAutoRetryNacksToggleField(),
 			service.NewTLSToggledField("tls"),
 		).
@@ -104,6 +108,7 @@ type websocketReader struct {
 
 	openMsgType wsOpenMsgType
 	openMsg     []byte
+	maxMsgSize  int
 }
 
 func newWebsocketReaderFromParsed(conf *service.ParsedConfig, mgr bundle.NewManagement) (*websocketReader, error) {
@@ -129,6 +134,12 @@ func newWebsocketReaderFromParsed(conf *service.ParsedConfig, mgr bundle.NewMana
 	}
 	if ws.reqSigner, err = conf.HTTPRequestAuthSignerFromParsed(); err != nil {
 		return nil, err
+	}
+	if ws.maxMsgSize, err = conf.FieldInt("max_message_size"); err != nil {
+		return nil, err
+	}
+	if ws.maxMsgSize < 0 {
+		return nil, fmt.Errorf("max_message_size must not be negative, got %v", ws.maxMsgSize)
 	}
 	var openMsgStr, openMsgTypeStr string
 	if openMsgTypeStr, err = conf.FieldString("open_message_type"); err != nil {
@@ -182,6 +193,10 @@ func (w *websocketReader) getConn(ctx context.Context) (*websocket.Conn, error) 
 		}
 	} else if client, res, err = dialer.Dial(w.urlStr, headers); err != nil {
 		return nil, err
+	}
+
+	if w.maxMsgSize > 0 {
+		client.SetReadLimit(int64(w.maxMsgSize))
 	}
 
 	return client, nil
@@ -240,6 +255,12 @@ func (w *websocketReader) ReadBatch(ctx context.Context) (message.Batch, input.A
 
 	_, data, err := client.ReadMessage()
 	if err != nil {
+		if errors.Is(err, websocket.ErrReadLimit) {
+			w.log.Error("Closing connection: received a message exceeding max_message_size")
+		}
+		// A read limit breach leaves the underlying socket open, so close
+		// before abandoning the connection for the reconnect path.
+		_ = client.Close()
 		w.lock.Lock()
 		w.client = nil
 		w.lock.Unlock()

--- a/internal/impl/io/input_websocket_test.go
+++ b/internal/impl/io/input_websocket_test.go
@@ -3,6 +3,7 @@
 package io
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"net/http"
@@ -192,6 +193,69 @@ open_message_type: %v
 			require.NoError(t, m.Close(ctx))
 		})
 	}
+}
+
+func TestWebsocketMaxMessageSize(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		upgrader := websocket.Upgrader{}
+
+		var ws *websocket.Conn
+		var err error
+		if ws, err = upgrader.Upgrade(w, r, nil); err != nil {
+			return
+		}
+
+		defer ws.Close()
+
+		if err = ws.WriteMessage(websocket.BinaryMessage, []byte("small")); err != nil {
+			t.Error(err)
+		}
+		if err = ws.WriteMessage(websocket.BinaryMessage, bytes.Repeat([]byte("x"), 1024)); err != nil {
+			t.Error(err)
+		}
+
+		// Wait for the client to drop the connection.
+		_, _, _ = ws.ReadMessage()
+	}))
+	t.Cleanup(server.Close)
+
+	wsURL, err := url.Parse(server.URL)
+	require.NoError(t, err)
+
+	wsURL.Scheme = "ws"
+
+	pConf, err := websocketInputSpec().ParseYAML(fmt.Sprintf(`
+url: %v
+max_message_size: 100
+`, wsURL.String()), nil)
+	require.NoError(t, err)
+
+	m, err := newWebsocketReaderFromParsed(pConf, mock.NewManager())
+	require.NoError(t, err)
+
+	ctx := t.Context()
+
+	require.NoError(t, m.Connect(ctx))
+
+	actMsg, _, err := m.ReadBatch(ctx)
+	require.NoError(t, err)
+	require.Equal(t, "small", string(actMsg.Get(0).AsBytes()))
+
+	_, _, err = m.ReadBatch(ctx)
+	require.ErrorIs(t, err, component.ErrNotConnected)
+
+	require.NoError(t, m.Close(ctx))
+}
+
+func TestWebsocketMaxMessageSizeNegative(t *testing.T) {
+	pConf, err := websocketInputSpec().ParseYAML(`
+url: ws://localhost:4195/get/ws
+max_message_size: -1
+`, nil)
+	require.NoError(t, err)
+
+	_, err = newWebsocketReaderFromParsed(pConf, mock.NewManager())
+	require.ErrorContains(t, err, "max_message_size must not be negative")
 }
 
 func TestWebsocketClose(t *testing.T) {


### PR DESCRIPTION
## Motivation

The `websocket` input reads messages with no inbound size bound: gorilla's read-limit guard (`conn.go:933`) never engages unless `SetReadLimit` is called, so a misbehaving or malicious server can send an arbitrarily large frame and exhaust memory. By comparison, `http_client` is bounded in both modes (codec `max_buffer` when streaming, request `timeout` otherwise).

This was flagged in a security review for enabling the `websocket` input on Redpanda Cloud (internal ref: SEC-228).

## Changes

- Adds an advanced `max_message_size` field (default `0` = disabled, negative values rejected at config parse) to the `websocket` input.
- When set, `SetReadLimit` is applied to the connection after each successful dial. A message exceeding the limit causes gorilla to close the connection with a 1009 (message too big) status; the input logs the breach and reconnects as it does for any other connection error.
- The `ErrReadLimit` case is logged explicitly in `ReadBatch`, since it is otherwise masked as `ErrNotConnected` and a persistent oversized message would look like a silent reconnect loop.

## Tests

- `TestWebsocketMaxMessageSize`: server sends a 5-byte then a 1KB message against a 100-byte limit — the first is delivered, the second drops the connection.
- `TestWebsocketMaxMessageSizeNegative`: negative values are rejected at config parse.

## Suggested changelog entry

- Input `websocket`: Added a `max_message_size` field that bounds the size of individual inbound messages via the underlying connection's read limit. (@prakhargarg105)

🤖 Generated with [Claude Code](https://claude.com/claude-code)