### PR TITLE
websocket: make the output dial honour its context

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,8 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
-- Input `websocket`: Connection attempts (dial and upgrade handshake) now honor context cancellation. Previously, unresponsive servers could
-  block graceful shutdown for up to the default 45s handshake timeout. (@Leward)
+- Input/Output `websocket`: Connection attempts (dial and upgrade handshake) now honor context cancellation. Previously, unresponsive
+  servers could block graceful shutdown for up to the default 45s handshake timeout. (@Leward)
 
 ## 4.78.0 - 2026-08-20
 

--- a/internal/impl/io/output_websocket.go
+++ b/internal/impl/io/output_websocket.go
@@ -135,16 +135,11 @@ func (w *websocketWriter) dial(ctx context.Context) (conn *websocket.Conn, res *
 	if w.proxyURLParsed != nil {
 		dialer.Proxy = http.ProxyURL(w.proxyURLParsed)
 	}
-
 	if w.tlsEnabled {
 		dialer.TLSClientConfig = w.tlsConf
-		if conn, res, err = dialer.Dial(w.urlStr, headers); err != nil {
-			return
-		}
-	} else if conn, res, err = dialer.Dial(w.urlStr, headers); err != nil {
-		return
 	}
 
+	conn, res, err = dialContext(ctx, dialer, w.urlStr, headers)
 	return
 }
 

--- a/internal/impl/io/output_websocket_test.go
+++ b/internal/impl/io/output_websocket_test.go
@@ -4,6 +4,7 @@ package io
 
 import (
 	"context"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"net/url"
@@ -110,4 +111,109 @@ websocket:
 
 	m.TriggerCloseNow()
 	require.NoError(t, m.WaitForClose(ctx))
+}
+
+// newWebsocketWriter returns a websocketWriter configured to connect to the websocket server listening on addr.
+func newWebsocketWriter(t *testing.T, addr net.Addr) *websocketWriter {
+	t.Helper()
+
+	pConf, err := websocketOutputSpec().ParseYAML("url: ws://"+addr.String()+"\n", nil)
+	require.NoError(t, err)
+
+	w, err := newWebsocketWriterFromParsed(pConf, mock.NewManager())
+	require.NoError(t, err)
+
+	return w
+}
+
+// newHangingWebsocketWriter returns a writer pointed at a listener that accepts
+// TCP connections but never answers the handshake, along with the accept channel
+// of that listener.
+func newHangingWebsocketWriter(t *testing.T) (*websocketWriter, <-chan struct{}) {
+	t.Helper()
+
+	addr, accepted := newHangingListener(t)
+	return newWebsocketWriter(t, addr), accepted
+}
+
+// newUnreachableWebsocketWriter returns a writer pointed at a closed port. A dial
+// there fails immediately, so a context error proves no dial was attempted.
+func newUnreachableWebsocketWriter(t *testing.T) *websocketWriter {
+	t.Helper()
+
+	return newWebsocketWriter(t, newUnreachableAddr(t))
+}
+
+// TestWebsocketOutputConnectContextDone tests that Connect reports the context
+// error when the context is done before or during the websocket handshake.
+func TestWebsocketOutputConnectContextDone(t *testing.T) {
+	tests := []struct {
+		name string
+		// setUp returns a writer and a context that is already done, or that becomes
+		// done while the dial waits for the handshake response. It also returns the
+		// accept channel to check after Connect returns, or nil for a case where no
+		// accept is expected.
+		setUp   func(*testing.T) (*websocketWriter, context.Context, <-chan struct{})
+		wantErr error
+	}{
+		{
+			name: "canceled before dialing",
+			setUp: func(t *testing.T) (*websocketWriter, context.Context, <-chan struct{}) {
+				ctx, cancel := context.WithCancel(t.Context())
+				cancel()
+				// The port is closed, so a dial fails at once. Only a context check
+				// before the dial can give context.Canceled here.
+				return newUnreachableWebsocketWriter(t), ctx, nil
+			},
+			wantErr: context.Canceled,
+		},
+		{
+			name: "canceled while dialing",
+			setUp: func(t *testing.T) (*websocketWriter, context.Context, <-chan struct{}) {
+				w, accepted := newHangingWebsocketWriter(t)
+
+				ctx, cancel := context.WithCancel(t.Context())
+				t.Cleanup(cancel)
+				// Cancel from the accept, not from a timer, so the dial always waits
+				// for the handshake response when the context becomes done.
+				go func() {
+					<-accepted
+					cancel()
+				}()
+
+				return w, ctx, nil
+			},
+			wantErr: context.Canceled,
+		},
+		{
+			name: "deadline exceeded while dialing",
+			setUp: func(t *testing.T) (*websocketWriter, context.Context, <-chan struct{}) {
+				w, accepted := newHangingWebsocketWriter(t)
+
+				// A context carries its deadline from the start, so this case cannot
+				// take its trigger from the accept. The accept check after Connect
+				// returns proves the deadline expired during the handshake.
+				ctx, cancel := context.WithTimeout(t.Context(), 50*time.Millisecond)
+				t.Cleanup(cancel)
+
+				return w, ctx, accepted
+			},
+			wantErr: context.DeadlineExceeded,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			w, ctx, accepted := test.setUp(t)
+
+			err := awaitWithin(t, 500*time.Millisecond, "Connect", func() error {
+				return w.Connect(ctx)
+			})
+			require.ErrorIs(t, err, test.wantErr)
+
+			if accepted != nil {
+				requireAccepted(t, 5*time.Second, accepted)
+			}
+		})
+	}
 }

--- a/internal/impl/io/output_websocket_test.go
+++ b/internal/impl/io/output_websocket_test.go
@@ -147,6 +147,8 @@ func newUnreachableWebsocketWriter(t *testing.T) *websocketWriter {
 // TestWebsocketOutputConnectContextDone tests that Connect reports the context
 // error when the context is done before or during the websocket handshake.
 func TestWebsocketOutputConnectContextDone(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name string
 		// setUp returns a writer and a context that is already done, or that becomes

--- a/internal/impl/io/output_websocket_test.go
+++ b/internal/impl/io/output_websocket_test.go
@@ -113,41 +113,35 @@ websocket:
 	require.NoError(t, m.WaitForClose(ctx))
 }
 
-// newWebsocketWriter returns a websocketWriter configured to connect to the websocket server listening on addr.
-func newWebsocketWriter(t *testing.T, addr net.Addr) *websocketWriter {
-	t.Helper()
-
-	pConf, err := websocketOutputSpec().ParseYAML("url: ws://"+addr.String()+"\n", nil)
-	require.NoError(t, err)
-
-	w, err := newWebsocketWriterFromParsed(pConf, mock.NewManager())
-	require.NoError(t, err)
-
-	return w
-}
-
-// newHangingWebsocketWriter returns a writer pointed at a listener that accepts
-// TCP connections but never answers the handshake, along with the accept channel
-// of that listener.
-func newHangingWebsocketWriter(t *testing.T) (*websocketWriter, <-chan struct{}) {
-	t.Helper()
-
-	addr, accepted := newHangingListener(t)
-	return newWebsocketWriter(t, addr), accepted
-}
-
-// newUnreachableWebsocketWriter returns a writer pointed at a closed port. A dial
-// there fails immediately, so a context error proves no dial was attempted.
-func newUnreachableWebsocketWriter(t *testing.T) *websocketWriter {
-	t.Helper()
-
-	return newWebsocketWriter(t, newUnreachableAddr(t))
-}
-
 // TestWebsocketOutputConnectContextDone tests that Connect reports the context
 // error when the context is done before or during the websocket handshake.
 func TestWebsocketOutputConnectContextDone(t *testing.T) {
 	t.Parallel()
+
+	newWebsocketWriter := func(t *testing.T, addr net.Addr) *websocketWriter {
+		t.Helper()
+
+		pConf, err := websocketOutputSpec().ParseYAML("url: ws://"+addr.String()+"\n", nil)
+		require.NoError(t, err)
+
+		w, err := newWebsocketWriterFromParsed(pConf, mock.NewManager())
+		require.NoError(t, err)
+
+		return w
+	}
+
+	newHangingWebsocketWriter := func(t *testing.T) (*websocketWriter, <-chan struct{}) {
+		t.Helper()
+
+		addr, accepted := newHangingListener(t)
+		return newWebsocketWriter(t, addr), accepted
+	}
+
+	newUnreachableWebsocketWriter := func(t *testing.T) *websocketWriter {
+		t.Helper()
+
+		return newWebsocketWriter(t, newUnreachableAddr(t))
+	}
 
 	tests := []struct {
 		name string


### PR DESCRIPTION
The output dial takes a context and discards it. A peer that accepts TCP and then stays silent keeps Connect blocked until the dialer handshake timeout of 45s, which blocks a graceful shutdown for that whole time.

Replace the dial with dialContext, which the input already uses. The tls and non-tls paths now differ only by the dialer field they set, so the duplicated dial call goes away.

Connect and ConnectionTest both pass a real context, and the async writer gives Connect a soft stop context. A dial to a silent peer now ends with the context error instead of running to the handshake timeout.

Add a test mirroring the input test, using the shared listener helpers so it only adds the writer constructors.

**Refs:**
- CON-545
- VM-75