### PR TITLE
websocket: honor context cancellation in input reads

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,8 +11,8 @@ All notable changes to this project will be documented in this file.
 
 ### Fixed
 
-- Input/Output `websocket`: Connection attempts (dial and upgrade handshake) now honor context cancellation. Previously, unresponsive
-  servers could block graceful shutdown for up to the default 45s handshake timeout. (@Leward)
+- Input/Output `websocket`: Connection attempts (dial and upgrade handshake) and input reads now honor context
+  cancellation, preventing graceful shutdown from hanging on unresponsive servers or idle connections. (@Leward)
 
 ## 4.78.0 - 2026-08-20
 

--- a/internal/impl/io/input_websocket.go
+++ b/internal/impl/io/input_websocket.go
@@ -250,27 +250,45 @@ func (w *websocketReader) Connect(ctx context.Context) error {
 	return nil
 }
 
+// dropConn closes client and forgets it, so the next read reconnects.
+func (w *websocketReader) dropConn(client *websocket.Conn) {
+	_ = client.Close()
+	w.lock.Lock()
+	if w.client == client { // guarded so a stale caller cannot clear a newer conn
+		w.client = nil
+	}
+	w.lock.Unlock()
+}
+
 func (w *websocketReader) ReadBatch(ctx context.Context) (message.Batch, input.AsyncAckFn, error) {
 	client := w.getWS()
 	if client == nil {
 		return nil, nil, component.ErrNotConnected
 	}
 
+	// ReadMessage doesn't accept a context, so cancellation closes the connection below to unblock it.
+	stop := context.AfterFunc(ctx, func() { _ = client.Close() })
 	_, data, err := client.ReadMessage()
+	stop()
+
 	if err != nil {
+		if ctx.Err() != nil {
+			// The read failed because cancellation closed the connection, not because of a real network error.
+			w.dropConn(client)
+			return nil, nil, ctx.Err()
+		}
+
 		if errors.Is(err, websocket.ErrReadLimit) {
 			w.log.Error("Closing connection: received a message exceeding max_message_size")
 		}
 		// A read limit breach leaves the underlying socket open, so close
 		// before abandoning the connection for the reconnect path.
-		_ = client.Close()
-		w.lock.Lock()
-		w.client = nil
-		w.lock.Unlock()
-		err = component.ErrNotConnected
-		return nil, nil, err
+		w.dropConn(client)
+		return nil, nil, component.ErrNotConnected
 	}
 
+	// Cancellation can close the socket after ReadMessage already parsed a message, so a nil error here can coexist with a cancelled ctx.
+	// Return the message anyway: the server will not resend it, so checking ctx.Err() here would drop it permanently.
 	return message.QuickBatch([][]byte{data}), func(ctx context.Context, err error) error {
 		return nil
 	}, nil

--- a/internal/impl/io/input_websocket_test.go
+++ b/internal/impl/io/input_websocket_test.go
@@ -348,9 +348,35 @@ func newUnreachableWebsocketReader(t *testing.T) *websocketReader {
 	return newWebsocketReader(t, newUnreachableAddr(t))
 }
 
+// newIdleWebsocketReader returns a reader pointed at a server that completes the
+// handshake and then sends nothing, so only the context can unblock a read.
+func newIdleWebsocketReader(t *testing.T) *websocketReader {
+	t.Helper()
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ws, err := (&websocket.Upgrader{}).Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer ws.Close()
+
+		// Hold the connection open until the client goes away.
+		for {
+			if _, _, err := ws.ReadMessage(); err != nil {
+				return
+			}
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	return newWebsocketReader(t, server.Listener.Addr())
+}
+
 // TestWebsocketConnectContextDone tests that Connect reports the context error
 // when the context is done before or during the websocket handshake.
 func TestWebsocketConnectContextDone(t *testing.T) {
+	t.Parallel()
+
 	tests := []struct {
 		name string
 		// setUp returns a reader and a context that is already done, or that becomes
@@ -363,10 +389,10 @@ func TestWebsocketConnectContextDone(t *testing.T) {
 		{
 			name: "canceled before dialing",
 			setUp: func(t *testing.T) (*websocketReader, context.Context, <-chan struct{}) {
-				ctx, cancel := context.WithCancel(t.Context())
-				cancel()
 				// The port is closed, so a dial fails at once. Only a context check
 				// before the dial can give context.Canceled here.
+				ctx, cancel := context.WithCancel(t.Context())
+				cancel()
 				return newUnreachableWebsocketReader(t), ctx, nil
 			},
 			wantErr: context.Canceled,
@@ -408,6 +434,8 @@ func TestWebsocketConnectContextDone(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
 			m, ctx, accepted := test.setUp(t)
 
 			err := awaitWithin(t, 500*time.Millisecond, "Connect", func() error {
@@ -420,4 +448,143 @@ func TestWebsocketConnectContextDone(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestWebsocketReadBatchContextDone tests that ReadBatch reports the context error instead of staying blocked on the
+// socket read of an established connection.
+func TestWebsocketReadBatchContextDone(t *testing.T) {
+	t.Parallel()
+
+	tests := []struct {
+		name    string
+		newCtx  func(*testing.T) context.Context
+		wantErr error
+	}{
+		{
+			name: "canceled before reading",
+			newCtx: func(t *testing.T) context.Context {
+				ctx, cancel := context.WithCancel(t.Context())
+				cancel()
+				return ctx
+			},
+			wantErr: context.Canceled,
+		},
+		{
+			name: "canceled while reading",
+			newCtx: func(t *testing.T) context.Context {
+				ctx, cancel := context.WithCancel(t.Context())
+				t.Cleanup(cancel)
+				// ReadBatch returns ctx.Err() whether the context goes done before
+				// or during the read, so a small delay cannot make this case flake.
+				time.AfterFunc(5*time.Millisecond, cancel)
+				return ctx
+			},
+			wantErr: context.Canceled,
+		},
+		{
+			name: "deadline exceeded while reading",
+			newCtx: func(t *testing.T) context.Context {
+				ctx, cancel := context.WithTimeout(t.Context(), 5*time.Millisecond)
+				t.Cleanup(cancel)
+				return ctx
+			},
+			wantErr: context.DeadlineExceeded,
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			t.Parallel()
+
+			m := newIdleWebsocketReader(t)
+			require.NoError(t, m.Connect(t.Context()))
+			// t.Context is canceled before cleanups run, so close with our own.
+			t.Cleanup(func() { _ = m.Close(context.Background()) })
+
+			ctx := test.newCtx(t)
+			err := awaitWithin(t, 500*time.Millisecond, "ReadBatch", func() error {
+				_, _, err := m.ReadBatch(ctx)
+				return err
+			})
+			require.ErrorIs(t, err, test.wantErr)
+		})
+	}
+}
+
+// TestWebsocketReadBatchCancelKeepsMessage tests that ReadBatch still delivers
+// an already-received message even if the context is done by then.
+// A websocket server never redelivers a message once sent.
+//
+// Cancellation closes the connection, and the close must not discard an already
+// buffered message. To pin that deterministically, the server sends two messages
+// in a single TCP write. The client's socket read then buffers both frames
+// together in userspace. The second ReadBatch parses its message from that buffer
+// and must return it even if the context was cancelled.
+//
+// Note on scope and limitations:
+// This test asserts the unit-level contract of websocketReader in isolation.
+// In practice, consumer components driving this reader (such as AsyncReader)
+// will NOT attempt further reads once context cancellation / soft-stop is
+// signalled, and may discard batches returned during teardown. Full end-to-end
+// in-flight message preservation during graceful shutdown remains an open gap
+// requiring framework-level drain support.
+func TestWebsocketReadBatchCancelKeepsMessage(t *testing.T) {
+	first, second := []byte("read first"), []byte("won't be redelivered")
+
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		ws, err := (&websocket.Upgrader{}).Upgrade(w, r, nil)
+		if err != nil {
+			return
+		}
+		defer ws.Close()
+
+		// Craft the two frames by hand and send them in one write. Two
+		// WriteMessage calls would be two writes, and the client's buffer
+		// fill could then pick up the first frame without the second: two
+		// separate writes often do land in the same read on loopback, but
+		// nothing guarantees it, so the test forces both into one.
+		var frames bytes.Buffer
+		for _, msg := range [][]byte{first, second} {
+			frames.WriteByte(0x80 | websocket.BinaryMessage) // FIN flag + opcode
+			frames.WriteByte(byte(len(msg)))                 // unmasked, single length byte
+			frames.Write(msg)
+		}
+		if _, err := ws.NetConn().Write(frames.Bytes()); err != nil {
+			t.Error(err)
+			return
+		}
+
+		// Hold the connection open until the client goes away.
+		for {
+			if _, _, err := ws.ReadMessage(); err != nil {
+				return
+			}
+		}
+	}))
+	t.Cleanup(server.Close)
+
+	// Init the websocket reader
+	m := newWebsocketReader(t, server.Listener.Addr())
+	require.NoError(t, m.Connect(t.Context()))
+	t.Cleanup(func() { _ = m.Close(context.Background()) })
+
+	// Read the first message
+	batch, _, err := m.ReadBatch(t.Context())
+	require.NoError(t, err)
+	require.Equal(t, first, batch.Get(0).AsBytes())
+
+	// Cancel the context (simulate a shutdown)
+	ctx, cancel := context.WithCancel(t.Context())
+	cancel()
+
+	// The context is already done, but the second frame is already buffered from
+	// the earlier socket read, so ReadBatch must return it instead of an error.
+	batch, _, err = m.ReadBatch(ctx)
+	require.NoError(t, err)
+	require.Equal(t, second, batch.Get(0).AsBytes())
+
+	// The cancellation closed the connection, so the next read reports a lost
+	// connection for the reconnect path.
+	_, _, err = m.ReadBatch(t.Context())
+	require.ErrorIs(t, err, component.ErrNotConnected)
 }


### PR DESCRIPTION
Refactor `ReadBatch` to handle context cancellations properly, ensuring idle connections or cancellation during reads do not block graceful shutdown.

Add comprehensive tests for input read behavior under various context cancellation scenarios.

Note for reviewers on `TestWebsocketReadBatchCancelKeepsMessage`:
- **Deterministic setup:** Packs two WebSocket frames into a single TCP write to ensure the second frame is buffered in userspace before cancellation.
- **Unit contract:** Asserts `websocketReader.ReadBatch` returns already-buffered messages rather than dropping them on `ctx.Err()`.
- **Scope limitation:** Tests the reader in isolation; end-to-end message preservation across the pipeline during shutdown remains subject to `AsyncReader` lifecycle handling.

**Refs:**
- CON-545
- VM-75