### PR TITLE
websocket: change the max_message_size default from unlimited to 32 MiB

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,12 @@ Changelog
 
 All notable changes to this project will be documented in this file.
 
+## Unreleased
+
+### Changed
+
+- Input `websocket`: The default value of `max_message_size` has changed from `0` (unlimited) to `33554432` (32 MiB). An unlimited read allows the websocket server to make the process allocate an unbounded amount of memory with a single streamed message. Pipelines that receive larger messages must now set `max_message_size` explicitly; a value of `0` restores the previous unlimited behaviour. (@Leward)
+
 ## 4.78.0 - 2026-08-20
 
 ### Added

--- a/internal/impl/io/input_websocket.go
+++ b/internal/impl/io/input_websocket.go
@@ -33,6 +33,11 @@ const (
 	wsOpenMsgTypeText wsOpenMsgType = "text"
 )
 
+// defaultMaxMessageSize bounds how much memory a single message from a remote
+// server can cost this process. It is generous, but finite: an unlimited
+// default allows any peer to OOM the process with one streamed frame.
+const defaultMaxMessageSize = 32 * 1024 * 1024
+
 func websocketInputSpec() *service.ConfigSpec {
 	return service.NewConfigSpec().
 		Stable().
@@ -55,8 +60,8 @@ func websocketInputSpec() *service.ConfigSpec {
 			}).Description("An optional flag to indicate the data type of open_message.").
 				Advanced().Default(string(wsOpenMsgTypeBinary)),
 			service.NewIntField("max_message_size").
-				Description("An optional maximum size in bytes for individual messages received from the server. When a message exceeding this limit is received the connection is closed with a 1009 (message too big) status and the input reconnects. A value of 0 disables the limit.").
-				Advanced().Default(0),
+				Description("A maximum size in bytes for individual messages received from the server. When a message exceeding this limit is received the connection is closed with a 1009 (message too big) status and the input reconnects. A value of 0 disables the limit, which allows the server to make this process allocate an unbounded amount of memory and is therefore not recommended.").
+				Advanced().Default(defaultMaxMessageSize),
 			service.NewAutoRetryNacksToggleField(),
 			service.NewTLSToggledField("tls"),
 		).

--- a/internal/impl/io/input_websocket_test.go
+++ b/internal/impl/io/input_websocket_test.go
@@ -247,6 +247,17 @@ max_message_size: 100
 	require.NoError(t, m.Close(ctx))
 }
 
+func TestWebsocketMaxMessageSizeDefault(t *testing.T) {
+	pConf, err := websocketInputSpec().ParseYAML(`
+url: ws://localhost:4195/get/ws
+`, nil)
+	require.NoError(t, err)
+
+	m, err := newWebsocketReaderFromParsed(pConf, mock.NewManager())
+	require.NoError(t, err)
+	require.Equal(t, defaultMaxMessageSize, m.maxMsgSize)
+}
+
 func TestWebsocketMaxMessageSizeNegative(t *testing.T) {
 	pConf, err := websocketInputSpec().ParseYAML(`
 url: ws://localhost:4195/get/ws


### PR DESCRIPTION
The websocket input's `max_message_size` shipped in `v4.78.0` with a default of 0: no read limit. This could allow a websocket server to make the process allocate an unbounded amount of memory with a single streamed message, leading to an OOM kill.

For existing configs the impact is limited. 32 MiB is a generous limit: typical websocket messages are orders of magnitude smaller. An explicit `max_message_size`, including 0 for unlimited, keeps its behaviour. The rare pipeline that receives larger messages fails loudly, not silently: the connection closes with a 1009 (message too big) status, an error is logged, and the input reconnects.

**Ref:**
 * CON-545
 * VM-73