### PR TITLE
docs: point the golang-lru links at pkg.go.dev

### DIFF
--- a/internal/impl/pure/cache_lru.go
+++ b/internal/impl/pure/cache_lru.go
@@ -44,7 +44,7 @@ func lruCacheConfig() *service.ConfigSpec {
 		Summary(`Stores key/value pairs in a lru in-memory cache. This cache is therefore reset every time the service restarts.`).
 		Description(`This provides the lru package which implements a fixed-size thread safe LRU cache.
 
-It uses the package ` + "https://github.com/hashicorp/golang-lru/v2[`lru`^]" + `
+It uses the package ` + "https://pkg.go.dev/github.com/hashicorp/golang-lru/v2[`lru`^]" + `
 
 The field ` + lruCacheFieldInitValuesLabel + ` can be used to pre-populate the memory cache with any number of key/value pairs:
 

--- a/internal/impl/pure/cache_ttlru.go
+++ b/internal/impl/pure/cache_ttlru.go
@@ -37,7 +37,7 @@ func ttlruCacheConfig() *service.ConfigSpec {
 
 This TTL is reset on both modification and access of the value. As a result, if the cache is full, and no items have expired, when adding a new item, the item with the soonest expiration will be evicted.
 
-It uses the package ` + "https://github.com/hashicorp/golang-lru/v2/expirable[`expirable`^]" + `
+It uses the package ` + "https://pkg.go.dev/github.com/hashicorp/golang-lru/v2/expirable[`expirable`^]" + `
 
 The field ` + ttlruCacheFieldInitValuesLabel + ` can be used to pre-populate the memory cache with any number of key/value pairs:
 


### PR DESCRIPTION
The `lru` and `ttlru` cache descriptions link the package they wrap as:

- `https://github.com/hashicorp/golang-lru/v2`
- `https://github.com/hashicorp/golang-lru/v2/expirable`

Those are **Go module paths, not GitHub paths**. `/v2` is a major-version suffix, not a directory in the repository, so both URLs 404. `pkg.go.dev` understands the module path, and it is the better destination anyway, since the sentence is about the package rather than the repository:

> It uses the package [`lru`]

Verified: both `pkg.go.dev/github.com/hashicorp/golang-lru/v2` and `.../v2/expirable` return 200; both `github.com/...` forms return 404.

## Why here and not in the docs

These `Description` strings are published as the `caches/lru` and `caches/ttlru` reference pages on docs.redpanda.com, which is how they turned up in the docs site's weekly link check ([redpanda-data/docs-site#211](https://github.com/redpanda-data/docs-site/issues/211)).

`caches/ttlru.adoc` in `rp-connect-docs` has already been hand-patched once, to `github.com/hashicorp/golang-lru/tree/main/expirable`, while its generated partial still carries the broken form. That patch is due to be overwritten on the next regen. Fixing the string at source is what makes the fix stick, for both pages.
